### PR TITLE
Fix log4j2.properties filter configuration

### DIFF
--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -1408,7 +1408,7 @@ logger.access_log_rolling.additivity = false
 logger.access_log_rolling.filter.regex.type = RegexFilter
 logger.access_log_rolling.filter.regex.regex = .*USR:(kibana|beat|logstash),.*
 logger.access_log_rolling.filter.regex.onMatch = DENY
-logger.access_log_rolling.filter.regex.onMisMatch = ACCEPT
+logger.access_log_rolling.filter.regex.onMismatch = ACCEPT
 
 ``` 
 


### PR DESCRIPTION
ES fails to start with proposed log4j2.properties, 