### PR TITLE
[ROR 1.26.0][RORDEV-269] response_fields rule

### DIFF
--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -950,7 +950,7 @@ Return documents deprived of all the fields, except the ones that:
 
 **NB:** You can only provide a full black list or white list. Grey lists \(i.e. `["~a", "b"]`\) are invalid settings and ROR will refuse to boot up if this condition is detected.
 
-*Example* Allow only `cluster_name` and `status` field in cluster health response:
+*Example*: allow only `cluster_name` and `status` field in cluster health response:
 
 ```
 - name: "Filter cluster health response"

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -988,7 +988,7 @@ response from above will look like:
 }
 ```
 
-**NB:** Any response field could be filtered using this rule.
+**NB:** Any response field can be filtered using this rule.
 
 ### Authentication
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -264,7 +264,7 @@ readonlyrest:
       indices: ["logstash-*"] # <-- This is a rule
 
     - name: "Block 2 - Blocking everything from a network"
-      type: forbid 
+      type: forbid
       hosts: ["10.0.0.0/24"] # <-- this is a rule
 ```
 
@@ -351,7 +351,7 @@ Optionally, it's possible to specify a list allowed SSL protocols and SSL cipher
 ```text
 readonlyrest:
     ssl:
-      # put the keystore in the same dir with elasticsearch.yml 
+      # put the keystore in the same dir with elasticsearch.yml
       keystore_file: "keystore.jks"
       keystore_pass: readonlyrest
       key_pass: readonlyrest
@@ -514,7 +514,7 @@ The rule has also an extended version:
 
 ```text
 indices:
-  patterns: ["sales", "logstash-*"]` 
+  patterns: ["sales", "logstash-*"]`
   must_involve_indices: false
 ```
 
@@ -681,30 +681,30 @@ In Elasticsearch, each request carries only one action. We extracted from Elasti
 Example actions \(see above for the full list\):
 
 ```text
- "cluster:admin/data_frame/delete" 
- "cluster:admin/data_frame/preview" 
+ "cluster:admin/data_frame/delete"
+ "cluster:admin/data_frame/preview"
  ...
- "cluster:monitor/data_frame/stats/get" 
- "cluster:monitor/health" 
- "cluster:monitor/main" 
- "cluster:monitor/nodes/hot_threads" 
- "cluster:monitor/nodes/info" 
+ "cluster:monitor/data_frame/stats/get"
+ "cluster:monitor/health"
+ "cluster:monitor/main"
+ "cluster:monitor/nodes/hot_threads"
+ "cluster:monitor/nodes/info"
 ...
- "indices:admin/aliases" 
- "indices:admin/aliases/get" 
- "indices:admin/analyze" 
+ "indices:admin/aliases"
+ "indices:admin/aliases/get"
+ "indices:admin/analyze"
 ...
- "indices:data/read/get" 
- "indices:data/read/mget" 
- "indices:data/read/msearch" 
+ "indices:data/read/get"
+ "indices:data/read/mget"
+ "indices:data/read/msearch"
  "indices:data/read/msearch/template"
  ...
- "indices:data/write/bulk" 
- "indices:data/write/bulk_shard_operations[s]" 
- "indices:data/write/delete" 
- "indices:data/write/delete/byquery" 
- "indices:data/write/index" 
- "indices:data/write/reindex" 
+ "indices:data/write/bulk"
+ "indices:data/write/bulk_shard_operations[s]"
+ "indices:data/write/delete"
+ "indices:data/write/delete/byquery"
+ "indices:data/write/index"
+ "indices:data/write/reindex"
  ...
  many more...
 ```
@@ -721,9 +721,9 @@ The idea is that with one single rule we allow the bare minimum set of index+act
 
 Possible access levels:
 
-* `ro_strict`: the browser has a read-only view on Kibana dashboards and settings and all other indices. 
-* `ro`: some write requests can go through to the `.kibana` index so that UI state in discover can be saved and short urls can be created. 
-* `rw`: some more actions will be allowed towards the `.kibana` index only, so Kibana dashboards and settings can be modified. 
+* `ro_strict`: the browser has a read-only view on Kibana dashboards and settings and all other indices.
+* `ro`: some write requests can go through to the `.kibana` index so that UI state in discover can be saved and short urls can be created.
+* `rw`: some more actions will be allowed towards the `.kibana` index only, so Kibana dashboards and settings can be modified.
 * `admin`: like above, but has additional permissions to use the ReadonlyREST PRO/Enterprise Kibana app.
 
 **NB:** The "admin" access level does not mean the user will be allowed to access all indices/actions. It's just like "rw" with settings changes privileges. If you want really unrestricted access for your Kibana user, including ReadonlyREST PRO/Enterprise app, set `kibana_access: unrestricted`. You can use this rule with the `users` rule to restrict access to selected admins.
@@ -789,12 +789,12 @@ If you want to allow write requests \(i.e. for Kibana sessions\), just duplicate
 
 #### `fields`
 
-This rule enables **Field Level Security \(FLS\)**. That is: 
+This rule enables **Field Level Security \(FLS\)**. That is:
 
 * for responses where fields with values are returned (e.g. Search/Get API) - filter and show only allowed fields
 * make not allowed fields unsearchable - used in QueryDSL requests (e.g. Search/MSearch API) do not have impact on search result.
 
-In other words: FLS protects from usage some not allowed fields for a certain user. From user's perspective it seems like such fields are nonexistent. 
+In other words: FLS protects from usage some not allowed fields for a certain user. From user's perspective it seems like such fields are nonexistent.
 
 **Definition**
 
@@ -808,7 +808,7 @@ Field rule definition consists of two parts:
 **Field names**
 
 Fields can be defined using two access modes: blacklist and whitelist.
- 
+
 **Blacklist mode \(recommended\)**
 
 Specifies which fields should not be allowed prefixed with `~` (other fields from mapping become allowed implicitly). Example:
@@ -819,7 +819,7 @@ Return documents but deprived of the fields that:
   * start with `excluded_fields_prefix_`
   * are equal to `excluded_field`
   * are equal to `another_excluded_field.nested_field`
-  
+
 **Whitelist mode**
 
 Specifies which fields should be allowed explicitly (other fields from mapping become not allowed implicitly).
@@ -828,7 +828,7 @@ Example:
 `fields: ["allowed_fields_prefix_*", "_*", "allowed_field.nested_field.text"]`
 
 Return documents deprived of all the fields, except the ones that:
- * start with `allowed_fields_prefix_` 
+ * start with `allowed_fields_prefix_`
  * start with underscore
  * are equal to `allowed_field.nested_field.text`
 
@@ -842,7 +842,7 @@ Example: hide prices from catalogue indices
   indices: ["catalogue_*"]
 ```
 
-**⚠️IMPORTANT** Any metadata fields e.g. `_id` or `_index` can not be used in `fields` rule. 
+**⚠️IMPORTANT** Any metadata fields e.g. `_id` or `_index` can not be used in `fields` rule.
 
 **⚠️IMPORTANT** The `filter`and `fields` rules will only affect "read" requests, therefore "write" requests **will not match** because otherwise it would implicitly allow clients to "write" without the filtering restriction. For reference, this behaviour is identical to x-pack and search guard.
 
@@ -878,7 +878,7 @@ The solution is to duplicate the block. The first one will intercept \(and filte
       auth_key: rw_user:pwd
       kibana_access: rw
       indices: ["r*"]  # <-- DO NOT FILTER THE .kibana INDEX!
-      filter: '{"query_string":{"query":"DestCountry:FR"}}' 
+      filter: '{"query_string":{"query":"DestCountry:FR"}}'
 
     - name: "::RW_USER (allow remaining requests)::"
       auth_key: rw_user:pwd
@@ -919,6 +919,46 @@ After adding the `filter` rule \(using the block duplication strategy\).
       kibana_hide_apps: ["readonlyrest_kbn", "timelion"]
       kibana_index: ".kibana_@{user}"
 ```
+
+#### `response_fields`
+
+This rule allows filtering Elasticsearch responses using defined list of fields. It works in very similar way to fields rule. However it **doesn't make use of Field Level Security \(FLS\)** and could be applied to every response returned by Elasticsearch.
+
+It could be configured in two modes: *whitelist* passing only defined fields or *blacklist* filtering out defined fields.
+
+**Blacklist mode**
+
+Specifies which fields should be filtered out with `~` (other fields from mapping become allowed implicitly). Example:
+
+`fields: ["~excluded_fields_prefix_*", "~excluded_field", "~another_excluded_field.nested_field"]`
+
+Return documents but deprived of the fields that:
+  * start with `excluded_fields_prefix_`
+  * are equal to `excluded_field`
+  * are equal to `another_excluded_field.nested_field`
+
+**Whitelist mode**
+
+In this mode rule is configured to filter out each field that isn't defined in rule.
+
+`response_fields: ["allowed_fields_prefix_*", "_*", "allowed_field.nested_field.text"]`
+
+Return documents deprived of all the fields, except the ones that:
+ * start with `allowed_fields_prefix_`
+ * start with underscore
+ * are equal to `allowed_field.nested_field.text`
+
+**NB:** You can only provide a full black list or white list. Grey lists \(i.e. `["~a", "b"]`\) are invalid settings and ROR will refuse to boot up if this condition is detected.
+
+*Example* Allow only `cluster_name` and `status` field in cluster health request:
+
+```
+- name: "Filter cluster health response"
+  uri_re: "^/_cluster/health"
+  response_fields: ["cluster_name", "status"]
+```
+
+Any field could be filtered using this rule.
 
 ### Authentication
 
@@ -1444,7 +1484,7 @@ Anywhere in `readonlyrest.yml` you can use the espression `${MY_ENV_VAR}` to rep
 For example, here we declare an environment variable, and we write `${LDAP_PASSWORD}` in our settings:
 
 ```bash
-$ export LDAP_PASSWORD=S3cr3tP4ss 
+$ export LDAP_PASSWORD=S3cr3tP4ss
 $ cat readonlyrest.yml
 ```
 
@@ -1539,18 +1579,18 @@ Here follow some examples of how to use JWT claims as dynamic variables in Reado
 
 ```yaml
 # Using JWT claims as dynamic variables
-indices: [ ".kibana_@{jwt:department}", "otherIdx" ] 
+indices: [ ".kibana_@{jwt:department}", "otherIdx" ]
 # claims = { "user": "u1", "department": "infosec"}
 # -> indices: [".kibana_infosec", "otherIdx"]
 
 # Using nested values in JWT using JSONPATH as dynamic variables
 indices: [ ".kibana_@{jwt:jsonpath.to.department}", "otherIdx"]  
-# claims = { "jsonpath": {"to": { "department": "infosec" }}} 
+# claims = { "jsonpath": {"to": { "department": "infosec" }}}
 # -> indices: [".kibana_infosec", "otherIdx"]
 
 # Referencing array-typed values from JWT claims will expand in a list of strings
 indices: [ ".kibana_@explode{jwt:allowedIndices}", "otherIdx"]  
-# claims = {"username": "u1", "allowedIndices":  ["x", "y"] } 
+# claims = {"username": "u1", "allowedIndices":  ["x", "y"] }
 # -> indices: [".kibana_x", ".kibana_y", "otherIdx"]
 
 # Explode operator will generate an array of strings from a comma-separated string
@@ -1623,7 +1663,7 @@ readonlyrest:
 
     access_control_rules:
 
-    - name: Accept requests to index1 from users with valid LDAP credentials, belonging to LDAP group 'team1' 
+    - name: Accept requests to index1 from users with valid LDAP credentials, belonging to LDAP group 'team1'
       ldap_authentication: "ldap1"  
       ldap_authorization:
         name: "ldap1"                                       # ldap name from 'ldaps' section
@@ -1675,7 +1715,7 @@ readonlyrest:
 * By default, users in `search_user_base_DN` should contain a `uid` LDAP attribute referring to a unique ID for the user within the base DN. An alternative attribute name can be specified via the optional `user_id_attribute` configuration item.
 * By default, groups in `search_groups_base_DN` should contain a `uniqueMember` LDAP attribute referring to the full DNs of the users that belong to the group. \(There may be any number of occurrences of this attribute within a particular group, as any number of users may belong to the group.\) An alternative attribute name can be specified via the optional `unique_member_attribute` configuration item.
 * `group_name_attribute` is the LDAP group object attribute that contains the names of the ROR groups
-* `group_search_filter` is the LDAP search filter \(or filters\) to limit the user groups returned by LDAP. By default, this filter will be joined \(with `&`\) with `unique_member_attribute=user_dn` filter resulting in this LDAP search filter: \(&YOUR\_GROUP\_SEARCH\_FILTER\(unique\_member\_attribute=user\_dn\)\). The `unique_member_attribute` can be set to use the value of `user_id_attribute` by setting `group_attribute_is_dn: false`. 
+* `group_search_filter` is the LDAP search filter \(or filters\) to limit the user groups returned by LDAP. By default, this filter will be joined \(with `&`\) with `unique_member_attribute=user_dn` filter resulting in this LDAP search filter: \(&YOUR\_GROUP\_SEARCH\_FILTER\(unique\_member\_attribute=user\_dn\)\). The `unique_member_attribute` can be set to use the value of `user_id_attribute` by setting `group_attribute_is_dn: false`.
 
 Examples:
 
@@ -1816,9 +1856,9 @@ readonlyrest:
         name: "jwt_provider_1"
         roles: ["writer"]
 
-    jwt: 
+    jwt:
     - name: jwt_provider_1
-      signature_algo: HMAC # can be NONE, RSA, HMAC (default), and EC 
+      signature_algo: HMAC # can be NONE, RSA, HMAC (default), and EC
       signature_key: "your_signature_min_256_chars"
       user_claim: email
       roles_claim: resource_access.client-app.roles # JSON-path style
@@ -1896,7 +1936,7 @@ See [commercial license FAQ page](https://github.com/beshu-tech/readonlyrest-doc
 
 1. Download the binary release of the latest version of ReadonlyREST from the [download page](https://readonlyrest.com/download.html)
 2. `cd` to the Elasticsearch home
-3. Install the plugin 
+3. Install the plugin
 
 **Elasticsearch 5.x**
 
@@ -1916,7 +1956,7 @@ See [commercial license FAQ page](https://github.com/beshu-tech/readonlyrest-doc
 
 You need to have installed: git, maven, Java 8 JDK, zip. So use apt-get or brew to get them.
 
-1. Clone the repo 
+1. Clone the repo
 
 ```bash
 git clone https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin
@@ -2046,4 +2086,3 @@ Of course, if you do not use ssl, disable it.
       actions: ["indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create"]
       indices: ["metricbeat-*", "log_metricbeat*"]
 ```
-

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -941,7 +941,7 @@ The above will return the usual response object, but deprived (if found) of the 
 
 **Whitelist mode**
 
-In this mode the rule is configured to filter out each field that isn't defined in rule.
+In this mode rule is configured to filter out each field that isn't defined in the rule.
 
 `response_fields: ["allowed_fields_prefix_*", "_*", "allowed_field.nested_field.text"]`
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -922,9 +922,11 @@ After adding the `filter` rule \(using the block duplication strategy\).
 
 #### `response_fields`
 
-This rule allows filtering Elasticsearch responses using defined list of fields. It works in very similar way to fields rule. However it **doesn't make use of Field Level Security \(FLS\)** and could be applied to every response returned by Elasticsearch.
+This rule allows filtering Elasticsearch responses using defined list of fields. It works in very similar way to `fields` rule. However in contrast to `fields` rule, which filters out document fields, this rule filters out response fields. It **doesn't make use of Field Level Security \(FLS\)** and could be applied to every response returned by Elasticsearch.
 
-It could be configured in two modes: *whitelist* passing only defined fields or *blacklist* filtering out defined fields.
+It could be configured in two modes:
+  * *whitelist* passing only defined fields
+  * *blacklist* filtering out defined fields.
 
 **Blacklist mode**
 
@@ -932,7 +934,7 @@ Specifies which fields should be filtered out with `~` (other fields from mappin
 
 `fields: ["~excluded_fields_prefix_*", "~excluded_field", "~another_excluded_field.nested_field"]`
 
-Return documents but deprived of the fields that:
+Return response but deprived of the fields that:
   * start with `excluded_fields_prefix_`
   * are equal to `excluded_field`
   * are equal to `another_excluded_field.nested_field`
@@ -943,7 +945,7 @@ In this mode rule is configured to filter out each field that isn't defined in r
 
 `response_fields: ["allowed_fields_prefix_*", "_*", "allowed_field.nested_field.text"]`
 
-Return documents deprived of all the fields, except the ones that:
+Return response deprived of all the fields, except the ones that:
  * start with `allowed_fields_prefix_`
  * start with underscore
  * are equal to `allowed_field.nested_field.text`
@@ -952,13 +954,41 @@ Return documents deprived of all the fields, except the ones that:
 
 *Example*: allow only `cluster_name` and `status` field in cluster health response:
 
+Without any filtering response from `/_cluster/health` looks more or less like:
+```
+{
+	"cluster_name": "ROR_SINGLE",
+	"status": "yellow",
+	"timed_out": false,
+	"number_of_nodes": 1,
+	"number_of_data_nodes": 1,
+	"active_primary_shards": 2,
+	"active_shards": 2,
+	"relocating_shards": 0,
+	"initializing_shards": 0,
+	"unassigned_shards": 2,
+	"delayed_unassigned_shards": 0,
+	"number_of_pending_tasks": 0,
+	"number_of_in_flight_fetch": 0,
+	"task_max_waiting_in_queue_millis": 0,
+	"active_shards_percent_as_number": 50.0
+}
+```
+but after configuring such rule:
 ```
 - name: "Filter cluster health response"
   uri_re: "^/_cluster/health"
   response_fields: ["cluster_name", "status"]
 ```
+response from above will look like:
+```
+{
+	"cluster_name": "ROR_SINGLE",
+	"status": "yellow"
+}
+```
 
-Any field could be filtered using this rule.
+**NB:** Any field could be filtered using this rule.
 
 ### Authentication
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -922,26 +922,26 @@ After adding the `filter` rule \(using the block duplication strategy\).
 
 #### `response_fields`
 
-This rule allows filtering Elasticsearch responses using defined list of fields. It works in very similar way to `fields` rule. However in contrast to `fields` rule, which filters out document fields, this rule filters out response fields. It **doesn't make use of Field Level Security \(FLS\)** and could be applied to every response returned by Elasticsearch.
+This rule allows filtering Elasticsearch responses using a list of fields. It works in very similar way to `fields` rule. In contrast to `fields` rule, which filters out document fields, this rule filters out response fields. It **doesn't make use of Field Level Security \(FLS\)** and can be applied to every response returned by Elasticsearch.
 
-It could be configured in two modes:
-  * *whitelist* passing only defined fields
-  * *blacklist* filtering out defined fields.
+It can be configured in two modes:
+  * *whitelist* allowing only the defined fields from the response object
+  * *blacklist* filtering out (removing) only the defined fields from the response object
 
 **Blacklist mode**
 
-Specifies which fields should be filtered out with `~` (other fields from mapping become allowed implicitly). Example:
+Specifies which fields should be filtered out by adding the ~ prefix to the field name. Other fields in the response will be implicitly allowed. For example:
 
-`fields: ["~excluded_fields_prefix_*", "~excluded_field", "~another_excluded_field.nested_field"]`
+`response_fields: ["~excluded_fields_prefix_*", "~excluded_field", "~another_excluded_field.nested_field"]`
 
-Return response but deprived of the fields that:
+The above will return the usual response object, but deprived (if found) of the fields that:
   * start with `excluded_fields_prefix_`
   * are equal to `excluded_field`
   * are equal to `another_excluded_field.nested_field`
 
 **Whitelist mode**
 
-In this mode rule is configured to filter out each field that isn't defined in rule.
+In this mode the rule is configured to filter out each field that isn't defined in rule.
 
 `response_fields: ["allowed_fields_prefix_*", "_*", "allowed_field.nested_field.text"]`
 
@@ -988,7 +988,7 @@ response from above will look like:
 }
 ```
 
-**NB:** Any field could be filtered using this rule.
+**NB:** Any response field could be filtered using this rule.
 
 ### Authentication
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -950,7 +950,7 @@ Return documents deprived of all the fields, except the ones that:
 
 **NB:** You can only provide a full black list or white list. Grey lists \(i.e. `["~a", "b"]`\) are invalid settings and ROR will refuse to boot up if this condition is detected.
 
-*Example* Allow only `cluster_name` and `status` field in cluster health request:
+*Example* Allow only `cluster_name` and `status` field in cluster health response:
 
 ```
 - name: "Filter cluster health response"


### PR DESCRIPTION
I see that atom removed unnecessary spaces from this document. Let me know if that's ok