### PR TITLE
[RORDEV-552] Impersonation docs

### DIFF
--- a/elasticsearch-details/impersonation.md
+++ b/elasticsearch-details/impersonation.md
@@ -1,0 +1,107 @@
+# Impersonation 
+
+According to [Wikipedia](https://en.wikipedia.org/wiki/Impersonator):
+
+> An impersonator is someone who imitates or copies the behavior or actions of another.
+
+So, an impersonation can be understood as imitating behaviors or actions.
+In the context of ReadonlyREST eg. one user could imitate an action 
+of another user. Why would we want it? Let's suppose the first user is 
+an admin, who has just configured access for a new user. He would like 
+to know if the rule or rules are configured correctly. And here it comes the impersonation feature. The admin can call ES request on behalf of the 
+tested user and authenticate using his credentials. 
+
+## Impersonators configuration
+
+Not anyone can be the impersonator. The list of impersonators and their permissions are defined in `impersonation` section:
+
+```yaml
+readonlyrest:
+  
+  access_control_rules:
+
+    [...]
+
+  impersonation:
+
+    - impersonator: admin1      // impersonator user name or pattern
+      users: ["*"]              // user name patterns that can be impersonated by the impersonator
+      auth_key: admin1:pass     // authentication rule (any authentication rule can be used here)
+
+    - impersonator: admin2
+      users: ["dev2"]
+      ldap_authentication: "ldap1"
+```
+
+We can read it as follows:
+
+1. The impersonator "admin1" can impersonate users which names match pattern `*` (any user) and the impersonator should be authenticated using `auth_key` rule.
+
+2. The impersonator "admin2" can impersonate only `dev2` and the impersonator should be authenticated using LDAP by `ldap1` connector.
+
+## Request with user impersonation
+
+Let's suppose our `user1` wants to search `twitter` index. He probably will call:
+
+```bash
+curl -vk -u user1:user_secret "https://localhost:9200/twitter/_search?pretty"
+```
+
+Now, how the same request would look like it our `admin1` wants to impersonate `user1` and search `twitter` on this behalf?
+
+```bash
+curl -vk -u admin1:pass -H "impersonate_as: user1" "https://localhost:9200/twitter/_search?pretty"
+```
+
+As we can see the request looks pretty much the same. The main difference is the `impersonate_as` header that contains `user1` and authorization header value has the admin's credentials now. 
+
+Responses of both requests should be the same.
+
+When the admin will pass wrong credentials or cannot impersonate the passed user
+ROR is going to return response like this:
+
+> ```text
+> HTTP/1.1 403 Forbidden
+> content-type: application/json; charset=UTF-8
+> 
+>{
+>  "error":{
+>    "root_cause":[
+>      {
+>        "type":"forbidden_response",
+>        "reason":"forbidden",
+>        "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_ALLOWED"]
+>      }
+>    ],
+>    "type":"forbidden_response",
+>    "reason":"forbidden",
+>    "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_ALLOWED"]
+>  },
+>  "status":403
+>}
+>```
+
+Some authentication or/and authorization rules (like LDAP ones or related to external systems) don't support impersonation by default (the support will be possible with cooperation with Kibana plugin soon). When request with impersonation
+will be rejected by rule that doesn't support impersonation, the caller should
+see result like this:
+
+> ```text
+> HTTP/1.1 403 Forbidden
+> content-type: application/json; charset=UTF-8
+> 
+>{
+>  "error":{
+>    "root_cause":[
+>      {
+>        "type":"forbidden_response",
+>        "reason":"forbidden",
+>        "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_SUPPORTED"]
+>      }
+>    ],
+>    "type":"forbidden_response",
+>    "reason":"forbidden",
+>    "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_SUPPORTED"]
+>  },
+>  "status":403
+>}
+>```

--- a/elasticsearch-details/impersonation.md
+++ b/elasticsearch-details/impersonation.md
@@ -5,15 +5,15 @@ According to [Wikipedia](https://en.wikipedia.org/wiki/Impersonator):
 > An impersonator is someone who imitates or copies the behavior or actions of another.
 
 So, an impersonation can be understood as imitating behaviors or actions.
-In the context of ReadonlyREST eg. one user could imitate an action 
+In the context of ReadonlyREST: one user could imitate an action 
 of another user. Why would we want it? Let's suppose the first user is 
-an admin, who has just configured access for a new user. He would like 
-to know if the rule or rules are configured correctly. And here it comes the impersonation feature. The admin can call ES request on behalf of the 
-tested user and authenticate using his credentials. 
+an admin, who has just configured access for a new user. They would like 
+to know if the rule(s) are configured correctly. And here it comes the impersonation feature. The admin can send an ES request on behalf of the 
+tested user and authenticate using their credentials. 
 
 ## Impersonators configuration
 
-Not anyone can be the impersonator. The list of impersonators and their permissions are defined in `impersonation` section:
+Not every user can be the impersonator. The list of allowed impersonators and their permissions are defined in the `impersonation` section:
 
 ```yaml
 readonlyrest:
@@ -24,9 +24,9 @@ readonlyrest:
 
   impersonation:
 
-    - impersonator: admin1      // impersonator user name or pattern
-      users: ["*"]              // user name patterns that can be impersonated by the impersonator
-      auth_key: admin1:pass     // authentication rule (any authentication rule can be used here)
+    - impersonator: admin1      // Who can impersonate? (user name or pattern)
+      users: ["*"]              // Who can be impersonated? (User names or patterns)
+      auth_key: admin1:pass     // Authentication rule required to impersonate (any authentication rule can be used here)
 
     - impersonator: admin2
       users: ["dev2"]
@@ -35,7 +35,7 @@ readonlyrest:
 
 We can read it as follows:
 
-1. The impersonator "admin1" can impersonate users which names match pattern `*` (any user) and the impersonator should be authenticated using `auth_key` rule.
+1. The impersonator "admin1" can impersonate users whose names match pattern `*` (any user) and the impersonator should be authenticated using `auth_key` rule.
 
 2. The impersonator "admin2" can impersonate only `dev2` and the impersonator should be authenticated using LDAP by `ldap1` connector.
 
@@ -47,18 +47,18 @@ Let's suppose our `user1` wants to search `twitter` index. He probably will call
 curl -vk -u user1:user_secret "https://localhost:9200/twitter/_search?pretty"
 ```
 
-Now, how the same request would look like it our `admin1` wants to impersonate `user1` and search `twitter` on this behalf?
+Now, how the same request would look like if our `admin1` wants to impersonate `user1` and search `twitter` on their behalf?
 
 ```bash
 curl -vk -u admin1:pass -H "impersonate_as: user1" "https://localhost:9200/twitter/_search?pretty"
 ```
 
-As we can see the request looks pretty much the same. The main difference is the `impersonate_as` header that contains `user1` and authorization header value has the admin's credentials now. 
+As we can see the request looks pretty much the same. The main difference is the `impersonate_as` header that contains `user1`, and authorization header value has the admin's credentials now. 
 
 Responses of both requests should be the same.
 
-When the admin will pass wrong credentials or cannot impersonate the passed user
-ROR is going to return response like this:
+Should the admin pass wrong credentials, or should they not be alowed to impersonate the user provided in the `impersonate_as` header, 
+ROR is going to return a response like the following:
 
 > ```text
 > HTTP/1.1 403 Forbidden
@@ -81,9 +81,9 @@ ROR is going to return response like this:
 >}
 >```
 
-Some authentication or/and authorization rules (like LDAP ones or related to external systems) don't support impersonation by default (the support will be possible with cooperation with Kibana plugin soon). When request with impersonation
-will be rejected by rule that doesn't support impersonation, the caller should
-see result like this:
+Some authentication or/and authorization rules (like LDAP ones or related to external systems) don't support impersonation by default (the support will be possible with cooperation with Kibana plugin soon). 
+
+When a request with impersonation is rejected because it triggers a rule that doesn't support impersonation, the caller will see this kind of response:
 
 > ```text
 > HTTP/1.1 403 Forbidden

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -897,6 +897,8 @@ Accepts [HTTP Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authenticat
 
 **⚠️IMPORTANT**: this rule is handy just for tests, replace it with another rule that hashes credentials, like: `auth_key_sha512`, or `auth_key_unix`.
 
+[Impersonation](elasticsearch-details/impersonation.md) is supported by this rule by default.
+
 #### `auth_key_sha512`
 
 `auth_key_sha512: 280ac6f...94bf9`
@@ -910,6 +912,8 @@ The rules support also alternative syntax, where only password is hashed, eg:
 `auth_key_sha512: "admin:280ac6f...94bf9"`
 
 In the example below `admin` is the username and `280ac6f...94bf9` is the hashed secret.
+
+[Impersonation](elasticsearch-details/impersonation.md) is supported by these rules by default.
 
 #### `auth_key_pbkdf2`
 
@@ -928,6 +932,7 @@ Accepts [HTTP Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authenticat
 
 The hash can be calculated using [this calculator](https://8gwifi.org/pbkdf.jsp) \(notice that the salt has to base Base64 encoded\).
 
+[Impersonation](elasticsearch-details/impersonation.md) is supported by this rule by default.
 #### `auth_key_unix`
 
 `auth_key_unix: test:$6$rounds=65535$d07dnv4N$QeErsDT9Mz.ZoEPXW3dwQGL7tzwRz.eOrTBepIwfGEwdUAYSy/NirGoOaNyPx8lqiR6DYRSsDzVvVbhP4Y9wf0 # Hashed for "test:test"`
@@ -988,6 +993,8 @@ if __name__ == '__main__':
 
 For example, `test` is the username and `$6$rounds=65535$d07dnv4N$QeErsDT9Mz.ZoEPXW3dwQGL7tzwRz.eOrTBepIwfGEwdUAYSy/NirGoOaNyPx8lqiR6DYRSsDzVvVbhP4Y9wf0` is the hash for `test` \(the password is identical to the username in this example\).
 
+[Impersonation](elasticsearch-details/impersonation.md) is supported by this rule by default.
+
 #### `proxy_auth: "*"`
 
 `proxy_auth: "*"`
@@ -999,6 +1006,8 @@ If you are using this technique for authentication using our **Kibana** plugins,
 `readonlyrest_kbn.proxy_auth_passthrough: true`
 
 So that Kibana will forward the necessary headers to Elasticsearch.
+
+[Impersonation](elasticsearch-details/impersonation.md) is supported by this rule by default.
 
 #### `users`
 
@@ -1051,7 +1060,10 @@ In general it looks like this:
     authentication_with_authorization_rule: ... # `ldap_auth` or `jwt_auth` or `ror_kbn_auth`
 ```
 
-For details see [User management](elasticsearch.md#users-and-groups) .
+For details see [User management](elasticsearch.md#users-and-groups).
+
+[Impersonation](elasticsearch-details/impersonation.md) supports depends on 
+authentication and authorization rules used in `users` section.
 
 #### `session_max_idle`
 
@@ -1103,17 +1115,26 @@ ldap_authorization:
 
 See the dedicated [LDAP section](elasticsearch.md#ldap-connector)
 
+[Impersonation](elasticsearch-details/impersonation.md) is not supported by default 
+by LDAP rules.
+
 #### `jwt_auth`
 
 See below, the dedicated [JSON Web Tokens section](elasticsearch.md#json-web-token-jwt-auth)
+
+[Impersonation](elasticsearch-details/impersonation.md) is not supported by this rule by default.
 
 #### `external-basic-auth`
 
 Used to delegate authentication to another server that supports HTTP Basic Auth. See below, the dedicated [External BASIC Auth section](elasticsearch.md#external-basic-auth)
 
+[Impersonation](elasticsearch-details/impersonation.md) is not supported by this rule by default.
+
 #### `groups_provider_authorization`
 
 Used to delegate groups resolution for a user to a JSON microservice. See below, the dedicated [Groups Provider Authorization section](elasticsearch.md#groups_provider_authorization)
+
+[Impersonation](elasticsearch-details/impersonation.md) is not supported by this rule by default.
 
 #### `ror_kbn_auth`
 
@@ -1143,6 +1164,8 @@ readonlyrest:
 This authentication and authorization connector represents the secure channel \(based on JWT tokens\) of signed messages necessary for our Enterprise Kibana plugin to securely pass back to ES the username and groups information coming from browser-driven authentication protocols like SAML
 
 Continue reading about this in the kibana plugin documentation, in the dedicated [SAML section](kibana/#saml)
+
+[Impersonation](elasticsearch-details/impersonation.md) is not supported by this rule by default.
 
 ### Ancillary rules
 


### PR DESCRIPTION
From the perspective of ROR ES only, impersonation is not supported by many rules. Until now there was no word about impersonation in our docs. Now, I've added a separate file with the description of the feature. 

ROR impersonation shines but only with ROR Auth Mock API and Test Settings API. The APIs are ROR internal ones and will be used by Kibana in the future. Also in the future, we will describe, from the perspective of Kibana, how to achieve full impersonation support.