### PR TITLE
fix license badge rendering

### DIFF
--- a/details/impersonation.md
+++ b/details/impersonation.md
@@ -1,4 +1,5 @@
-# Impersonation ([Enterprise](https://readonlyrest.com/enterprise))
+# Impersonation 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 After describing what [the impersonation is](../kibana.md#impersonation), it's high time to see how ROR supports it and who and when could be interested in using this feature. Let's start with the latter.
 

--- a/examples/custom-middleware/README.md
+++ b/examples/custom-middleware/README.md
@@ -2,7 +2,8 @@
 description: Custom middleware 
 ---
 
-# Custom middleware ([Enterprise](https://readonlyrest.com/enterprise))
+# Custom middleware 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 Sometimes, Enterprise users might need more flexibility and customize the plugin behavior to adjust the product to the business needs.
 There are two options to declare the custom middleware:

--- a/examples/impersonation/README.md
+++ b/examples/impersonation/README.md
@@ -2,7 +2,8 @@
 description: Impersonation
 ---
 
-# Impersonation ([Enterprise](https://readonlyrest.com/enterprise))
+# Impersonation 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 According to [Wikipedia](https://en.wikipedia.org/wiki/Impersonator):
 

--- a/examples/multitenancy_guide.md
+++ b/examples/multitenancy_guide.md
@@ -1,4 +1,5 @@
-# Multi-tenancy Elastic Stack ([Enterprise](https://readonlyrest.com/enterprise))
+# Multi-tenancy Elastic Stack 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 This document will guide you through setting up your Elasticsearch and Kibana stack with ReadonlyREST such that:
 

--- a/examples/multiuser_guide.md
+++ b/examples/multiuser_guide.md
@@ -1,4 +1,5 @@
-# Multi-user Elastic Stack ([PRO](https://readonlyrest.com/pro))
+# Multi-user Elastic Stack 
+([PRO](https://readonlyrest.com/pro))
 
 This document will guide you through setting up your Elasticsearch and Kibana stack with ReadonlyREST such that:
 

--- a/examples/oidc-sso/README.md
+++ b/examples/oidc-sso/README.md
@@ -2,7 +2,8 @@
 description: External connectors integration
 ---
 
-# OpenID Connect (OIDC) SSO ([Enterprise](https://readonlyrest.com/enterprise))
+# OpenID Connect (OIDC) SSO 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 With ReadonlyREST Enterprise, you can integrate with OpenID Connect (OIDC) Single Sign-on identity providers for both authentication and authorization.
 

--- a/examples/saml-sso/README.md
+++ b/examples/saml-sso/README.md
@@ -2,7 +2,8 @@
 description: External connectors integration
 ---
 
-# SAML SSO ([Enterprise](https://readonlyrest.com/enterprise))
+# SAML SSO 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 With ReadonlyREST Enterprise, you can integrate with SAML 2.0 Single Sign-on identity providers for both authentication and authorization.
 

--- a/kibana/readonlyrest-api.md
+++ b/kibana/readonlyrest-api.md
@@ -4,7 +4,8 @@ description: >-
   ES cluster.
 ---
 
-# ReadonlyREST API ([Enterprise](https://readonlyrest.com/enterprise))
+# ReadonlyREST API 
+([Enterprise](https://readonlyrest.com/enterprise))
 
 As an Enterprise user, you can benefit from automating the security configuration changes without the need to reboot the ES cluster.
 


### PR DESCRIPTION
Rendering the license badge is a problem for first-level headers. In those cases, let's place the badge below the header.

<img width="901" alt="image" src="https://github.com/user-attachments/assets/399150a7-82fa-4b35-acee-22a8d3470627">
