### PR TITLE
RORDEV-1444 user info source methods description

### DIFF
--- a/kibana.md
+++ b/kibana.md
@@ -1165,6 +1165,28 @@ There are two available methods for authentication:
 
 1. **client_secret_basic** (default): The `client_id` and `client_secret` are sent using the Authorization header, as specified in [RFC 6749, Section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). Before sending, the `client_id` and `client_secret` are encoded.
 2. **client_secret_post**: The `client_id` and `client_secret` are included in the request body, following the guidelines in [RFC 6749, Section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). In this method, the `client_id` and `client_secret` are not encoded before being sent. Choose this method when the OpenID Connect provider, such as [lemonLDAP::NG](https://lemonldap-ng.org/), cannot decode the encoded values.
+
+The following description explains the available options for the setting:
+
+### User Info Source Methods
+
+You can configure where the ReadonlyREST Kibana plugin obtains the OIDC user profile information using the `userInfoSource` option in the `readonlyrest_kbn.auth.oidc_kc` block. There are two available methods:
+
+1. **user_info_endpoint** (default):  
+   When set to `user_info_endpoint`, the plugin makes an additional call to the URL specified under `userInfoURL` to retrieve the most up-to-date user profile information from the OIDC provider.
+
+2. **access_token**:  
+   When set to `access_token`, the plugin extracts the user profile information directly from the access token.
+
+For example, you can configure it as follows:
+
+```yaml
+readonlyrest_kbn:
+   auth:
+      oidc_kc:
+         userInfoSource: 'access_token'  # Available options: 'user_info_endpoint' (default) or 'access_token'
+```
+
 ## Load balancers
 
 These features will work with all ReadonlyREST Editions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced the Kibana plugin guide with clearer instructions for configuring OpenID Connect (OIDC) user profile retrieval.
  - Detailed two approaches for obtaining user profile information: one via an external endpoint (default) and another by extracting it directly from the access token.
  - Added a new configuration option `userInfoSource` with an illustrative example to assist users in setup, while retaining existing client authentication instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->