### PR TITLE
RORDEV-1344 provide readonlyrest_kbn.logPrettyPrintEnabled flag description

### DIFF
--- a/kibana.md
+++ b/kibana.md
@@ -331,7 +331,8 @@ ReadonlyREST for Kibana is almost entirely remote-controlled from the Elasticsea
 
 ### ROR Settings in kibana.yml
 
-* `readonlyrest_kbn.logLevel: <trace|debug|info>`: for extra visibility set debug or (rarely) trace. Keep in mind `trace` could leak secrets into logs, so be careful.
+* `readonlyrest_kbn.logLevel: <trace|debug|info|error|warn>`: for extra visibility set debug or (rarely) trace. Keep in mind `trace` could leak secrets into logs, so be careful.
+* `readonlyrest_kbn.logPrettyPrintEnabled: true|false`: if you want to see pretty-printed or compact logs.
 * [session configuration](#session-management-with-multiple-kibana-instances)
 * [UI customisation](#login-screen-tweaking)
 * [custom middleware](#custom-middleware)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include `error` and `warn` as allowed values for the log level setting.
  - Added information about a new option for enabling or disabling pretty-printed log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->