### PR TITLE
[RORDEV-1478] Instruction for upgrading ES/KBN version with ROR plugin

### DIFF
--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -388,10 +388,10 @@ Depending on your environment.
 The ReadonlyREST plugin version must always match the currently installed Elasticsearch version.
 As a result, if you want to upgrade Elasticsearch:
 
-1. Before upgrading Elasticsearch unpatch and uninstall the ReadonlyREST plugin according to the instructions:
+1. Before upgrading Elasticsearch, unpatch and uninstall the ReadonlyREST plugin according to the instructions:
     * [Unpatch Elasticsearch and uninstall the plugin](elasticsearch.md#removing-the-plugin)
 2. Upgrade Elasticsearch.
-3. After upgrading Elasticsearch install the matching version of the ReadonlyREST plugin and patch according to the instructions:
+3. After upgrading Elasticsearch, install the matching version of the ReadonlyREST plugin and patch according to the instructions:
     * [Install matching plugin version and patch Elasticsearch](elasticsearch.md#installing-the-plugin)
 
 {% hint style="warning" %}

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -385,12 +385,19 @@ Depending on your environment.
 
 ### Upgrading Elasticsearch
 
-The ReadonlyREST plugin version must always match the currently installed Elasticsearch version.\
+The ReadonlyREST plugin version must always match the currently installed Elasticsearch version.
 As a result, if you want to upgrade Elasticsearch:
 
-1. Before upgrading Elasticsearch unpatch and uninstall the ReadonlyREST plugin according to the [instruction](elasticsearch.md#removing-the-plugin)
-2. Upgrade Elasticsearch
-3. After upgrading Elasticsearch install the matching version of the ReadonlyREST plugin and patch according to the [instruction](elasticsearch.md#installing-the-plugin)
+1. Before upgrading Elasticsearch unpatch and uninstall the ReadonlyREST plugin according to the instructions:
+    * [Unpatch Elasticsearch and uninstall the plugin](elasticsearch.md#removing-the-plugin)
+2. Upgrade Elasticsearch.
+3. After upgrading Elasticsearch install the matching version of the ReadonlyREST plugin and patch according to the instructions:
+    * [Install matching plugin version and patch Elasticsearch](elasticsearch.md#installing-the-plugin)
+
+{% hint style="warning" %}
+Upgrading Elasticsearch without following the instructions above may cause 
+corruption of the ES installation and inability to patch the upgraded version.
+{% endhint %}
 
 ### Deploying ReadonlyREST in a stable production cluster
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -383,6 +383,14 @@ service start elasticsearch
 
 Depending on your environment.
 
+### Upgrading Elasticsearch
+
+The ReadonlyREST plugin version must always match the currently installed Elasticsearch version.\
+As a result, if you want to upgrade Elasticsearch:
+
+1. Before upgrading Elasticsearch unpatch and uninstall the ReadonlyREST plugin according to the [instruction](elasticsearch.md#removing-the-plugin)
+2. Upgrade Elasticsearch
+3. After upgrading Elasticsearch install the matching version of the ReadonlyREST plugin and patch according to the [instruction](elasticsearch.md#installing-the-plugin)
 
 ### Deploying ReadonlyREST in a stable production cluster
 

--- a/kibana.md
+++ b/kibana.md
@@ -286,11 +286,11 @@ bin/kibana-plugin remove readonlyrest_kbn
 The ReadonlyREST plugin version must always match the currently installed Kibana version.
 As a result, if you want to upgrade Kibana with ROR plugin installed:
 
-1. Before upgrading Kibana unpatch and uninstall the ReadonlyREST plugin according to the instructions:
+1. Before upgrading Kibana, unpatch and uninstall the ReadonlyREST plugin according to the instructions:
     * [Unpatch Kibana](kibana.md#unpatching-kibana)
     * [Uninstall the plugin](kibana.md#uninstalling)
 2. Upgrade Kibana.
-3. After upgrading Kibana install the matching version of the ReadonlyREST plugin and patch according to the instructions:
+3. After upgrading Kibana, install the matching version of the ReadonlyREST plugin and patch according to the instructions:
    * [Install matching plugin version](kibana.md#installation)
    * [Patch Kibana](kibana.md#patching-kibana)
 

--- a/kibana.md
+++ b/kibana.md
@@ -281,7 +281,20 @@ And the classic uninstall command...
 bin/kibana-plugin remove readonlyrest_kbn
 ```
 
-### Upgrading
+### Upgrading Kibana
+
+The ReadonlyREST plugin version must always match the currently installed Kibana version.\
+As a result, if you want to upgrade Kibana with ROR plugin installed:
+
+1. Before upgrading Kibana unpatch and uninstall the ReadonlyREST plugin according to the instructions:
+    * [Unpatch Kibana](kibana.md#unpatching-kibana)
+    * [Uninstall the plugin](kibana.md#uninstalling)
+2. Upgrade Kibana
+3. After upgrading Kibana install the matching version of the ReadonlyREST plugin and patch according to the instructions
+   * [Install matching plugin version](kibana.md#installation)
+   * [Patch Kibana](kibana.md#patching-kibana)
+
+### Upgrading ReadonlyREST plugin
 
 To upgrade to a new version of ReadonlyREST plugin for Kibana, you should:
 

--- a/kibana.md
+++ b/kibana.md
@@ -283,16 +283,21 @@ bin/kibana-plugin remove readonlyrest_kbn
 
 ### Upgrading Kibana
 
-The ReadonlyREST plugin version must always match the currently installed Kibana version.\
+The ReadonlyREST plugin version must always match the currently installed Kibana version.
 As a result, if you want to upgrade Kibana with ROR plugin installed:
 
 1. Before upgrading Kibana unpatch and uninstall the ReadonlyREST plugin according to the instructions:
     * [Unpatch Kibana](kibana.md#unpatching-kibana)
     * [Uninstall the plugin](kibana.md#uninstalling)
-2. Upgrade Kibana
-3. After upgrading Kibana install the matching version of the ReadonlyREST plugin and patch according to the instructions
+2. Upgrade Kibana.
+3. After upgrading Kibana install the matching version of the ReadonlyREST plugin and patch according to the instructions:
    * [Install matching plugin version](kibana.md#installation)
    * [Patch Kibana](kibana.md#patching-kibana)
+
+{% hint style="warning" %}
+Upgrading Kibana without following the instructions above may cause
+corruption of the Kibana installation and inability to patch the upgraded version.
+{% endhint %}
 
 ### Upgrading ReadonlyREST plugin
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions for upgrading Elasticsearch and Kibana when using the ReadonlyREST plugin, emphasizing the need to match plugin versions with the respective platform versions.
  - Clarified step-by-step procedures for safely uninstalling, upgrading, and reinstalling the ReadonlyREST plugin during upgrades.
  - Improved organization with new section headers for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->