### PR TITLE
RORDEV-1612 OIDC clock-skew-tolerance configuration in kibana.yml

### DIFF
--- a/kibana.md
+++ b/kibana.md
@@ -1268,9 +1268,6 @@ readonlyrest_kbn.auth:
       clockToleranceSeconds: 5  # Default is 0 seconds
 ```
 
-
-```yaml
-
 #### Client Additional Parameters
 You can find a list of all supported parameters:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining OpenID Connect clock skew tolerance.
  * Introduced the clockToleranceSeconds configuration option for OIDC, with a YAML example.
  * Clarified that the default value is 0 seconds and demonstrated setting it to 5 seconds.
  * Supplemented the “Client Additional Parameters” area with this OIDC-specific parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->