### PR TITLE
Fix ACL documentation discrepancies from source code audit

### DIFF
--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -828,6 +828,19 @@ The groups rules use the user definitions from [the `users` section](#users-and-
 - after this step, we have an authorized user with information about the authorized groups to which the user belongs
 - then we check whether the authorized user groups are permitted in context of the rule
 
+{% hint style="info" %}
+**Groups rule aliases**: For backwards compatibility, the following YAML key aliases are recognized and treated identically to their canonical names:
+
+| Canonical Rule | Aliases |
+|---------------|---------|
+| `groups_any_of` | `groups`, `any_of`, `groups_or`, `roles` |
+| `groups_all_of` | `all_of`, `groups_and`, `roles_and` |
+| `groups_not_any_of` | `not_any_of` |
+| `groups_not_all_of` | `not_all_of` |
+
+Similarly, `headers_and` can be written as `headers`.
+{% endhint %}
+
 ##### `groups_any_of`
 
 The ACL block will match when the user belongs to any of the specified groups (boolean OR logic).
@@ -1120,6 +1133,8 @@ Used to delegate authentication to another server that supports HTTP Basic Auth.
 For more information on the ROR's authorization rules, see [Authorization rules details](details/authorization-rules-details.md)
 
 #### `groups_provider_authorization`
+
+Also available as the alias `external_authorization`.
 
 Used to delegate groups resolution for a user to a JSON microservice. See below, the dedicated [Groups Provider Authorization section](elasticsearch.md#custom-groups-providers)
 
@@ -1804,9 +1819,9 @@ Match if **at least one** the specified HTTP headers `key:value` pairs is matche
 
 Match if **at least one** specified regular expression matches requested URI.
 
-#### `maxBodyLength`
+#### `max_body_length`
 
-`maxBodyLength: 0`
+`max_body_length: 0`
 
 Match requests having a request body length less or equal to an integer. Use `0` to match only requests without body.
 
@@ -1817,6 +1832,12 @@ Match requests having a request body length less or equal to an integer. Use `0`
 `api_keys: [123456, abcdefg]`
 
 A list of api keys expected in the header `X-Api-Key`
+
+#### `response_headers`
+
+`response_headers: ["X-Custom-Header:value", "X-Another:123"]`
+
+Add custom headers to the Elasticsearch HTTP response when this block matches. Useful for passing metadata (e.g. group names, routing hints) back to clients or proxies.
 
 #### `session_max_idle`
 
@@ -2103,6 +2124,23 @@ ldaps:
 ```
 
 And ReadonlyREST ES will load "S3cr3tP4ss" as `bind_password`.
+
+### Incompatible rule combinations
+
+Certain rules cannot be used together within a single ACL block. ReadonlyREST will report a validation error if any of these combinations are detected:
+
+| Rule A | Rule B | Reason |
+|--------|--------|--------|
+| `kibana_access` | `actions` | Kibana access internally manages action filtering |
+| `kibana_access` | `filter` | Kibana access conflicts with Document Level Security |
+| `kibana_access` | `fields` | Kibana access conflicts with Field Level Security |
+| `kibana_access` | `response_fields` | Kibana access conflicts with response field filtering |
+
+{% hint style="info" %}
+The composite `kibana` rule does **not** have these conflicts — it replaces the legacy separate rules (`kibana_access`, `kibana_index`, `kibana_hide_apps`, `kibana_template_index`) and handles these interactions internally.
+{% endhint %}
+
+Additionally, a block with an **authorization-only** rule (e.g. `ldap_authorization`, `jwt_authorization`) must also contain an **authentication** rule in the same block. A block cannot have more than one authentication rule.
 
 ### Dynamic variables
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -839,6 +839,8 @@ The groups rules use the user definitions from [the `users` section](#users-and-
 | `groups_not_all_of` | `not_all_of` |
 
 Similarly, `headers_and` can be written as `headers`.
+
+These aliases apply only to **ACL rule keys inside access control blocks** — they are unrelated to the `groups` field in the [`users` section](#users-and-groups).
 {% endhint %}
 
 ##### `groups_any_of`


### PR DESCRIPTION
## Summary

Cross-referenced the public documentation against the plugin source code and found several discrepancies. This PR fixes the verified issues:

- **`maxBodyLength` → `max_body_length`**: The YAML key was incorrectly documented in camelCase. The actual plugin key is snake_case.
- **Missing `response_headers` rule**: This rule exists in the plugin but had zero documentation. Added description and usage example.
- **Group rule aliases undocumented**: The canonical group rule names (`groups_any_of`, `groups_all_of`, etc.) have widely-used aliases (`groups`, `roles`, `any_of`, etc.) that were not mentioned. Added an alias reference table.
- **`external_authorization` alias missing**: This alias for `groups_provider_authorization` was not mentioned.
- **Incompatible rule combinations undocumented**: Added a new section documenting which rules cannot coexist in a single block (e.g. `kibana_access` + `actions`/`filter`/`fields`/`response_fields`), plus the auth-only rule pairing requirement.

## Test plan

- [ ] Verify `max_body_length` is the correct key name in the plugin source
- [ ] Verify `response_headers` rule description matches plugin behavior
- [ ] Verify group aliases table matches `Rule.Name(...)` definitions in source
- [ ] Verify incompatible combinations match `IncompatibleRules` checks in source
- [ ] Review rendered markdown for formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added backward-compatible YAML aliases for group rules and external authorization (including headers alias and provider alias "external_authorization").
  * Standardized config key naming (maxBodyLength → max_body_length).
  * Added response_headers examples to set custom HTTP response headers.
  * Documented incompatible rule combinations and authorization-only rule requirements.
  * Expanded dynamic variables with acl, header, and jwt contexts and updated Groups examples/readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->