### PR TITLE
[RORDEV-1303]` xpack.security.enabled: false` is no longer required in ROR

### DIFF
--- a/details/kibana-7.8.x-and-older.md
+++ b/details/kibana-7.8.x-and-older.md
@@ -387,7 +387,6 @@ Open up `conf/kibana.yml` and add the following:
 xpack.graph.enabled: false
 xpack.ml.enabled: false
 xpack.monitoring.enabled: true
-xpack.security.enabled: false # this is fundamental!
 xpack.watcher.enabled: false
 
 # Kibana server use ::KIBANA-SRV:: credentials

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -31,7 +31,7 @@ The following diagram models an instance of Elasticsearch with the ReadonlyREST 
 3. The HTTP stack in Elasticsearch parses the HTTP request
 4. The HTTP handler in Elasticsearch extracts the indices, action, request type, and creates a `SearchRequest` \(internal Elasticsearch format\).
 5. The SearchRequest goes through the ACL \(access control list\), external systems like LDAP can be asynchronously queried, and an exit result is eventually produced.
-6.7.0 The exit result is used by the audit event serializer, to write a record to index and/or Elasticsearch log file
+6. The exit result is used by the audit event serializer, to write a record to index and/or Elasticsearch log file
 7. If no ACL block was matched, or if a `type: forbid` block was matched, ReadonlyREST does not forward the search request to the search engine and creates an "unauthorized" HTTP response.
 8. In case the ACL matches a `type: allow` block, the request is forwarded to the search engine
 9. The Elasticsearch code creates a search response containing the results of the query
@@ -131,7 +131,7 @@ When prompted about additional permissions, answer **y**.
 
 #### 3. Patch Elasticsearch
 
-If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to `plugins/readonlyrest` directory.
+If you are using Elasticsearch 6.7.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to `plugins/readonlyrest` directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar patch --I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes
@@ -232,7 +232,7 @@ depending on your environment.
 
 #### 2. Unpatch Elasticsearch
 
-If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
+If you are using Elasticsearch 6.7.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar unpatch
@@ -265,12 +265,12 @@ bin/elasticsearch-plugin install file://<download_dir>/readonlyrest-<ROR_VERSION
 e.g.
 
 ```bash
-bin/elasticsearch-plugin install file:///tmp/readonlyrest-1.56.7.00_es8.12.2.zip
+bin/elasticsearch-plugin install file:///tmp/readonlyrest-1.56.0_es8.12.2.zip
 ```
 
 #### 5. Patch Elasticsearch
 
-If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to the `plugins/readonlyrest` directory.
+If you are using Elasticsearch 6.7.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to the `plugins/readonlyrest` directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar patch --I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes
@@ -292,7 +292,7 @@ jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar verify
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar --help
 ```
 
-#### 6.7.0 Restart Elasticsearch.
+#### 6 Restart Elasticsearch.
 
 ```bash
 bin/elasticsearch
@@ -324,7 +324,7 @@ depending on your environment.
 
 #### 2. Unpatch Elasticsearch
 
-If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
+If you are using Elasticsearch 6.7.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar unpatch
@@ -481,17 +481,15 @@ It wraps connection between client and exposed REST API in SSL context, hence ma
 http.type: ssl_netty4
 ```
 
-Now in `readonlyrest.yml` add the following settings:
+Now in `elasticsearch.yml` add the following settings:
 
 ```yaml
-readonlyrest:
-  ssl:
-    keystore_file: "keystore.jks" # or keystore.p12 for PKCS#12 format
-    keystore_pass: readonlyrest
-    key_pass: readonlyrest
+readonlyrest.ssl.keystore_file: "keystore.jks"  # or keystore.p12 for PKCS#12 format
+readonlyrest.ssl.keystore_pass: readonlyrest
+readonlyrest.ssl.key_pass: readonlyrest
 ```
 
-The keystore should be stored in the same directory with `elasticsearch.yml` and `readonlyrest.yml`.
+The keystore should be stored in the same directory as `elasticsearch.yml`.
 
 #### Internode communication - transport module
 
@@ -503,17 +501,15 @@ This option encrypts communication between nodes forming Elasticsearch cluster.
 transport.type: ror_ssl_internode
 ```
 
-In `readonlyrest.yml` following settings must be added \(it's just example configuration presenting most important properties\):
+In `elasticsearch.yml` add the following settings (example configuration with the most important properties):
 
 ```yaml
-readonlyrest:
-  ssl_internode:
-    keystore_file: "keystore.jks" # or keystore.p12 for PKCS#12 format
-    keystore_pass: readonlyrest
-    key_pass: readonlyrest
+readonlyrest.ssl_internode.keystore_file: "keystore.jks"  # or keystore.p12 for PKCS#12 format
+readonlyrest.ssl_internode.keystore_pass: readonlyrest
+readonlyrest.ssl_internode.key_pass: readonlyrest
 ```
 
-Similar to `ssl` for HTTP, the keystore should be stored in the same directory with `elasticsearch.yml` and `readonlyrest.yml`. This config must be added to all nodes taking part in encrypted communication within cluster.
+Similar to `ssl` for HTTP, the keystore should be stored in the same directory as `elasticsearch.yml`. This config must be added to all nodes taking part in encrypted communication within cluster.
 
 ##### Internode communication with XPack nodes
 
@@ -521,19 +517,17 @@ It is possible to set up internode SSL between ROR nodes (with `xpack.security.e
 
 To set up cluster in such configuration you have to generate certificate for ROR node according to this description https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html#generate-certificates.
 
-Generated `elastic-certificates.p12` could be then used in ROR node with such configuration
+Generated `elastic-certificates.p12` could be then used in ROR node with such configuration in `elasticsearch.yml`:
 ```yaml
-readonlyrest:
-  ssl_internode:
-    enable: true
-    keystore_file: "elastic-certificates.p12"
-    keystore_pass: [ password for generated certificate ]
-    key_pass: [ password for generated certificate ]
-    truststore_file: "elastic-certificates.p12"
-    truststore_pass: [ password for generated certificate ]
-    client_authentication: true # default: false
-    certificate_verification: true # certificate verification is enabled by default on XPack nodes 
-    hostname_verification: false # hostname verification is disabled by default
+readonlyrest.ssl_internode.enable: true
+readonlyrest.ssl_internode.keystore_file: "elastic-certificates.p12"
+readonlyrest.ssl_internode.keystore_pass: [ password for generated certificate ]
+readonlyrest.ssl_internode.key_pass: [ password for generated certificate ]
+readonlyrest.ssl_internode.truststore_file: "elastic-certificates.p12"
+readonlyrest.ssl_internode.truststore_pass: [ password for generated certificate ]
+readonlyrest.ssl_internode.client_authentication: true  # default: false
+readonlyrest.ssl_internode.certificate_verification: true  # certificate verification is enabled by default on XPack nodes
+readonlyrest.ssl_internode.hostname_verification: false  # hostname verification is disabled by default
 ```
 
 #### Certificate verification
@@ -542,17 +536,17 @@ By default the certificate verification is disabled. It means that certificate i
 It is useful on local/test environment, where security is not the most important concern. On production environment it is advised to enable this option. It can be done by means of:
 
 ```yaml
-certificate_verification: true
+readonlyrest.ssl_internode.certificate_verification: true
 ```
 
-under `ssl_internode` section. This option is applicable only for internode SSL.
+This option is applicable only for internode SSL.
 
 #### Hostname verification
 
 By default the hostname verification is disabled. This means that hostname or IP address is not verified to match the names in the certificate. To enable hostname verification add the following lines in the `ssl_internode` section:
 
 ```yaml
-hostname_verification: true
+readonlyrest.ssl_internode.hostname_verification: true
 ```
 
 #### Client authentication
@@ -560,24 +554,21 @@ hostname_verification: true
 By default the client authentication is disabled. When enabled, the server asks the client about its certificate, so ES is able to verify the client's identity. It can be enabled by means of:
 
 ```yaml
-client_authentication: true
+readonlyrest.ssl.client_authentication: true
 ```
 
-under `ssl` section. This option is applicable for REST API external SSL and internode SSL.
+This option is applicable for REST API external SSL and internode SSL (use `readonlyrest.ssl_internode.client_authentication` for internode).
 
 #### Restrict SSL protocols and ciphers
 
 Optionally, it's possible to specify a list allowed SSL protocols and SSL ciphers. Connections from clients that don't support the listed protocols or ciphers will be dropped.
 
 ```yaml
-readonlyrest:
-  ssl:
-    # put the keystore in the same dir with elasticsearch.yml
-    keystore_file: "keystore.jks"
-    keystore_pass: readonlyrest
-    key_pass: readonlyrest
-    allowed_protocols: [TLSv1.2]
-    allowed_ciphers: [TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+readonlyrest.ssl.keystore_file: "keystore.jks"
+readonlyrest.ssl.keystore_pass: readonlyrest
+readonlyrest.ssl.key_pass: readonlyrest
+readonlyrest.ssl.allowed_protocols: [TLSv1.2]
+readonlyrest.ssl.allowed_ciphers: [TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
 ```
 
 ReadonlyREST will log a list of available ciphers and protocols supported by the current JVM at startup.
@@ -595,26 +586,26 @@ ReadonlyREST will log a list of available ciphers and protocols supported by the
 ReadonlyREST allows using custom truststore, replacing \(provided by JRE\) default one. Custom truststore can be set with:
 
 ```yaml
-truststore_file: "truststore.jks"
-truststore_pass: truststorepass
+readonlyrest.ssl.truststore_file: "truststore.jks"
+readonlyrest.ssl.truststore_pass: truststorepass
 ```
 
-under `ssl` or `ssl_internode` section. This option is applicable for both ssl modes - external ssl and internode ssl. The truststore should be stored in the same directory with `elasticsearch.yml` and `readonlyrest.yml` \(like keystore\). When not specified, ReadonlyREST uses default truststore.
+Use `readonlyrest.ssl_internode.truststore_file` / `readonlyrest.ssl_internode.truststore_pass` for internode SSL. This option is applicable for both ssl modes - external ssl and internode ssl. The truststore should be stored in the same directory as `elasticsearch.yml` (like the keystore). When not specified, ReadonlyREST uses the default truststore.
 
 
 #### PEM files instead of a keystore and/or truststore
 
 If you are using ReadonlyREST 1.44.0 or newer then you are able to use PEM files directly without the need of placing them inside a keystore or truststore.  
 
-To use PEM files instead of keystore file, use such configuration instead of `keystore_file`, `keystore_pass`, `key_pass` fields: 
+To use PEM files instead of keystore file, use such configuration in `elasticsearch.yml` instead of `keystore_file`, `keystore_pass`, `key_pass` fields:
 ```yaml
-server_certificate_key_file: private_key.pem
-server_certificate_file: cert_chain.pem
+readonlyrest.ssl.server_certificate_key_file: private_key.pem
+readonlyrest.ssl.server_certificate_file: cert_chain.pem
 ```
 
-To use PEM file instead of truststore file, use such configuration instead of `truststore_file`, `truststore_pass` fields: 
+To use PEM file instead of truststore file, use such configuration instead of `truststore_file`, `truststore_pass` fields:
 ```yaml
-client_trusted_certificate_file: trusted_certs.pem
+readonlyrest.ssl.client_trusted_certificate_file: trusted_certs.pem
 ```
 
 #### Using Let's encrypt

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -435,7 +435,7 @@ The YAML snippet above, like all of this plugin's settings should be saved insid
 
 ### Encryption
 
-An SSL-encrypted connection is a prerequisite for secure exchange of credentials and data over the network. To make use of it you need to have a certificate and private key. [Letsencrypt](https://letsencrypt.org/) certificates work just fine (see tutorial below). Before ReadonlyREST 1.44.0 both files, certificate and private key, had to be placed inside PKCS#12 or JKS keystore. See the tutorial at the end of this section. ReadonlyREST 1.44.0 or newer supports using PEM files directly, without the need to use a keystore.
+SSL/TLS encryption protects data in transit between clients and Elasticsearch. ReadonlyREST supports two independent encryption layers, each covering a different communication channel:
 
 Traffic can be encrypted on two independent levels:
 1. HTTP/REST API (port 9200)
@@ -568,7 +568,6 @@ ReadonlyREST will log a list of available ciphers and protocols supported by the
 [2018-01-03T10:09:38,684][INFO ][t.b.r.e.SSLTransportNetty4] ROR SSL: Restricting to ciphers: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 [2018-01-03T10:09:38,684][INFO ][t.b.r.e.SSLTransportNetty4] ROR SSL: Available SSL protocols: TLSv1,TLSv1.1,TLSv1.2
 [2018-01-03T10:09:38,685][INFO ][t.b.r.e.SSLTransportNetty4] ROR SSL: Restricting to SSL protocols: TLSv1.2
-[2018-0
 ```
 
 #### Custom truststore

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -31,7 +31,7 @@ The following diagram models an instance of Elasticsearch with the ReadonlyREST 
 3. The HTTP stack in Elasticsearch parses the HTTP request
 4. The HTTP handler in Elasticsearch extracts the indices, action, request type, and creates a `SearchRequest` \(internal Elasticsearch format\).
 5. The SearchRequest goes through the ACL \(access control list\), external systems like LDAP can be asynchronously queried, and an exit result is eventually produced.
-6. The exit result is used by the audit event serializer, to write a record to index and/or Elasticsearch log file
+6.7.0 The exit result is used by the audit event serializer, to write a record to index and/or Elasticsearch log file
 7. If no ACL block was matched, or if a `type: forbid` block was matched, ReadonlyREST does not forward the search request to the search engine and creates an "unauthorized" HTTP response.
 8. In case the ACL matches a `type: allow` block, the request is forwarded to the search engine
 9. The Elasticsearch code creates a search response containing the results of the query
@@ -131,7 +131,7 @@ When prompted about additional permissions, answer **y**.
 
 #### 3. Patch Elasticsearch
 
-If you are using Elasticsearch 6.5.x or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to `plugins/readonlyrest` directory.
+If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to `plugins/readonlyrest` directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar patch --I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes
@@ -182,19 +182,7 @@ readonlyrest:
       auth_key: user:password
 ```
 
-#### 5. Disable X-Pack security module
-
-**\(applies to ES 6.4.0 or greater\)**
-
-ReadonlyREST and X-Pack security module can't run together, so the latter needs to be disabled.
-
-Edit `elasticsearch.yml` and append `xpack.security.enabled: false`.
-
-```bash
-vim $ES_PATH_CONF/conf/elasticsearch.yml
-```
-
-#### 6. Start Elasticsearch
+#### 5. Start Elasticsearch
 
 ```bash
 bin/elasticsearch
@@ -244,7 +232,7 @@ depending on your environment.
 
 #### 2. Unpatch Elasticsearch
 
-If you are using Elasticsearch 6.5.x or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
+If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar unpatch
@@ -277,12 +265,12 @@ bin/elasticsearch-plugin install file://<download_dir>/readonlyrest-<ROR_VERSION
 e.g.
 
 ```bash
-bin/elasticsearch-plugin install file:///tmp/readonlyrest-1.56.0_es8.12.2.zip
+bin/elasticsearch-plugin install file:///tmp/readonlyrest-1.56.7.00_es8.12.2.zip
 ```
 
 #### 5. Patch Elasticsearch
 
-If you are using Elasticsearch 6.5.x or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to the `plugins/readonlyrest` directory.
+If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra post-installation step**. Depending on the [Elasticsearch version](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/blob/master/ror-tools-core/src/main/scala/tech/beshu/ror/tools/core/patches), this command might tweak the main Elasticsearch installation files and/or copy some jars to the `plugins/readonlyrest` directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar patch --I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes
@@ -304,7 +292,7 @@ jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar verify
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar --help
 ```
 
-#### 6. Restart Elasticsearch.
+#### 6.7.0 Restart Elasticsearch.
 
 ```bash
 bin/elasticsearch
@@ -336,7 +324,7 @@ depending on your environment.
 
 #### 2. Unpatch Elasticsearch
 
-If you are using Elasticsearch 6.5.x or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
+If you are using Elasticsearch 6.7.07.0 or newer, you need **an extra pre-uninstallation step**. This will remove all previously copied jars from ROR's installation directory.
 
 ```bash
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar unpatch
@@ -501,7 +489,7 @@ Similar to `ssl` for HTTP, the keystore should be stored in the same directory w
 
 ##### Internode communication with XPack nodes
 
-It is possible to set up internode SSL between ROR and XPack nodes. It works only for ES above 6.3.
+It is possible to set up internode SSL between ROR and XPack nodes. It works only for ES above 6.7.07.0.
 
 To set up cluster in such configuration you have to generate certificate for ROR node according to this description https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html#generate-certificates.
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -475,15 +475,10 @@ The following subsections describe how to configure SSL using ReadonlyREST's own
 #### External REST API
 
 It wraps connection between client and exposed REST API in SSL context, hence making it encrypted and secure.
-**⚠️IMPORTANT:** To enable SSL for REST API, open `elasticsearch.yml` and append this one line:
+**⚠️IMPORTANT:** To enable SSL for REST API, open `elasticsearch.yml` and add the following settings (example configuration with the most important properties):
 
 ```yaml
 http.type: ssl_netty4
-```
-
-Now in `elasticsearch.yml` add the following settings:
-
-```yaml
 readonlyrest.ssl.keystore_file: "keystore.jks"  # or keystore.p12 for PKCS#12 format
 readonlyrest.ssl.keystore_pass: readonlyrest
 readonlyrest.ssl.key_pass: readonlyrest
@@ -495,15 +490,10 @@ The keystore should be stored in the same directory as `elasticsearch.yml`.
 
 This option encrypts communication between nodes forming Elasticsearch cluster.
 
-**⚠️IMPORTANT:** To enable SSL for internode communication open `elasticsearch.yml` and append this one line:
+**⚠️IMPORTANT:** To enable SSL for internode communication open `elasticsearch.yml` and add these (example configuration with the most important properties):
 
 ```yaml
 transport.type: ror_ssl_internode
-```
-
-In `elasticsearch.yml` add the following settings (example configuration with the most important properties):
-
-```yaml
 readonlyrest.ssl_internode.keystore_file: "keystore.jks"  # or keystore.p12 for PKCS#12 format
 readonlyrest.ssl_internode.keystore_pass: readonlyrest
 readonlyrest.ssl_internode.key_pass: readonlyrest

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -468,11 +468,11 @@ When `xpack.security.enabled` is `true`, configure SSL by following the official
 
 ROR's ACL will handle authentication and authorization, while XPack manages the SSL layer transparently.
 
-#### ROR SSL (when `xpack.security.enabled: false`)
+#### ReadonlyREST SSL (when `xpack.security.enabled: false`)
 
 The following subsections describe how to configure SSL using ReadonlyREST's own SSL implementation. This applies only when `xpack.security.enabled` is set to `false` in `elasticsearch.yml`.
 
-#### External REST API
+##### External REST API
 
 It wraps connection between client and exposed REST API in SSL context, hence making it encrypted and secure.
 **⚠️IMPORTANT:** To enable SSL for REST API, open `elasticsearch.yml` and add the following settings (example configuration with the most important properties):
@@ -486,7 +486,7 @@ readonlyrest.ssl.key_pass: readonlyrest
 
 The keystore should be stored in the same directory as `elasticsearch.yml`.
 
-#### Internode communication - transport module
+##### Internode communication - transport module
 
 This option encrypts communication between nodes forming Elasticsearch cluster.
 
@@ -501,7 +501,7 @@ readonlyrest.ssl_internode.key_pass: readonlyrest
 
 Similar to `ssl` for HTTP, the keystore should be stored in the same directory as `elasticsearch.yml`. This config must be added to all nodes taking part in encrypted communication within cluster.
 
-##### Internode communication with XPack nodes
+###### Internode communication with XPack nodes
 
 It is possible to set up internode SSL between ROR nodes (with `xpack.security.enabled: false`) and XPack nodes. It works only for ES above 6.7.0.
 
@@ -520,7 +520,7 @@ readonlyrest.ssl_internode.certificate_verification: true  # certificate verific
 readonlyrest.ssl_internode.hostname_verification: false  # hostname verification is disabled by default
 ```
 
-#### Certificate verification
+###### Certificate verification
 
 By default the certificate verification is disabled. It means that certificate is not validated in any way, so all certificates are accepted.
 It is useful on local/test environment, where security is not the most important concern. On production environment it is advised to enable this option. It can be done by means of:
@@ -531,7 +531,7 @@ readonlyrest.ssl_internode.certificate_verification: true
 
 This option is applicable only for internode SSL.
 
-#### Hostname verification
+###### Hostname verification
 
 By default the hostname verification is disabled. This means that hostname or IP address is not verified to match the names in the certificate. To enable hostname verification add the following lines in the `ssl_internode` section:
 
@@ -539,7 +539,7 @@ By default the hostname verification is disabled. This means that hostname or IP
 readonlyrest.ssl_internode.hostname_verification: true
 ```
 
-#### Client authentication
+###### Client authentication
 
 By default the client authentication is disabled. When enabled, the server asks the client about its certificate, so ES is able to verify the client's identity. It can be enabled by means of:
 
@@ -549,7 +549,7 @@ readonlyrest.ssl.client_authentication: true
 
 This option is applicable for REST API external SSL and internode SSL (use `readonlyrest.ssl_internode.client_authentication` for internode).
 
-#### Restrict SSL protocols and ciphers
+##### Restrict SSL protocols and ciphers
 
 Optionally, it's possible to specify a list allowed SSL protocols and SSL ciphers. Connections from clients that don't support the listed protocols or ciphers will be dropped.
 
@@ -570,7 +570,7 @@ ReadonlyREST will log a list of available ciphers and protocols supported by the
 [2018-01-03T10:09:38,685][INFO ][t.b.r.e.SSLTransportNetty4] ROR SSL: Restricting to SSL protocols: TLSv1.2
 ```
 
-#### Custom truststore
+##### Custom truststore
 
 ReadonlyREST allows using custom truststore, replacing \(provided by JRE\) default one. Custom truststore can be set with:
 
@@ -582,7 +582,7 @@ readonlyrest.ssl.truststore_pass: truststorepass
 Use `readonlyrest.ssl_internode.truststore_file` / `readonlyrest.ssl_internode.truststore_pass` for internode SSL. This option is applicable for both ssl modes - external ssl and internode ssl. The truststore should be stored in the same directory as `elasticsearch.yml` (like the keystore). When not specified, ReadonlyREST uses the default truststore.
 
 
-#### PEM files instead of a keystore and/or truststore
+##### PEM files instead of a keystore and/or truststore
 
 If you are using ReadonlyREST 1.44.0 or newer then you are able to use PEM files directly without the need of placing them inside a keystore or truststore.  
 
@@ -597,25 +597,25 @@ To use PEM file instead of truststore file, use such configuration instead of `t
 readonlyrest.ssl.client_trusted_certificate_file: trusted_certs.pem
 ```
 
-#### Using Let's encrypt
+##### Using Let's encrypt
 We are  going to show how to first add all the certificates and private key into PKCS#12 keystore, and then (optionally) converting it to JKS keystore. ReadonlyREST supports both formats.
 
 **⚠️IMPORTANT**: if you are using ReadonlyREST in version above 1.44.0 then you don't have to create a keystore. You are able to use PEM files directly using the description above. 
 
 This tutorial can be a useful example on how to use certificates from other providers. 
 
-##### 1. Create keys
+###### 1. Create keys
 ```bash
 ./letsencrypt-auto certonly --standalone -d DOMAIN.TLD -d DOMAIN_2.TLD --email EMAIL@EMAIL.TLD
 ```
 Now change to the directory (probably /etc/letsencrypt/live/DOMAIN.tld) where the certificates were created.
 
-##### 2. Create a PKCS12 keystore with the full chain and private key
+###### 2. Create a PKCS12 keystore with the full chain and private key
 ```bash
 openssl pkcs12 -export -in fullchain.pem -inkey privkey.pem -out pkcs.p12 -name NAME
 ```
 
-##### 3. Convert PKCS12 to JKS Keystore (Optional)
+###### 3. Convert PKCS12 to JKS Keystore (Optional)
 The STORE_PASS is the password which was entered in step 2) as a password for the pkcs12 file.
 
 ```bash

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -441,18 +441,18 @@ Traffic can be encrypted on two independent levels:
 1. HTTP/REST API (port 9200)
 2. Internode communication - transport module (port 9300)
 
-#### Choosing between ROR SSL and XPack Security SSL
+#### Choosing between ReadonlyREST SSL and XPack Security SSL
 
 There are two ways to configure SSL in an Elasticsearch cluster running ReadonlyREST:
 
-- **ROR SSL** — SSL provided by the ReadonlyREST plugin itself (described in the subsections below).
+- **ReadonlyREST SSL** — SSL provided by the ReadonlyREST plugin itself (described in the subsections below).
 - **XPack Security SSL** — SSL provided by Elasticsearch's built-in `xpack.security` module.
 
 The choice depends on whether `xpack.security.enabled` is set to `true` or `false` in `elasticsearch.yml`:
 
 | `xpack.security.enabled` | SSL to use |
 |---|---|
-| `false` | ROR SSL |
+| `false` | ReadonlyREST SSL |
 | `true` | XPack Security SSL |
 
 **Why does this matter?** During its patching step, ReadonlyREST deactivates XPack Security's authentication and authorization features — these are replaced by ROR's ACL engine. However, **XPack SSL is not deactivated**. This means that when `xpack.security.enabled: true`, XPack SSL is still fully active and must be configured through Elasticsearch's standard mechanism, not through ROR.

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -292,7 +292,7 @@ jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar verify
 jdk/bin/java -jar plugins/readonlyrest/ror-tools.jar --help
 ```
 
-#### 6 Restart Elasticsearch.
+#### 6. Restart Elasticsearch
 
 ```bash
 bin/elasticsearch
@@ -503,7 +503,7 @@ Similar to `ssl` for HTTP, the keystore should be stored in the same directory a
 
 ###### Internode communication with XPack nodes
 
-It is possible to set up internode SSL between ROR nodes (with `xpack.security.enabled: false`) and XPack nodes. It works only for ES above 6.7.0.
+It is possible to set up internode SSL between ROR nodes (with `xpack.security.enabled: false`) and XPack nodes. It works only for ES 6.7.0 or newer.
 
 To set up cluster in such configuration you have to generate certificate for ROR node according to this description https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html#generate-certificates.
 

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -435,14 +435,42 @@ The YAML snippet above, like all of this plugin's settings should be saved insid
 
 ### Encryption
 
-An SSL-encrypted connection is a prerequisite for secure exchange of credentials and data over the network. To make use of it you need to have certificate and private key. [Letsencrypt](https://letsencrypt.org/) certificates work just fine (see tutorial below). Before ReadonlyREST 1.44.0 both files, certificate and private key, had to be placed inside PKCS#12 or JKS keystore. See the tutorial at the end of this section. ReadonlyREST 1.44.0 or newer supports using PEM files directly, without the need to use a keystore. 
+An SSL-encrypted connection is a prerequisite for secure exchange of credentials and data over the network. To make use of it you need to have a certificate and private key. [Letsencrypt](https://letsencrypt.org/) certificates work just fine (see tutorial below). Before ReadonlyREST 1.44.0 both files, certificate and private key, had to be placed inside PKCS#12 or JKS keystore. See the tutorial at the end of this section. ReadonlyREST 1.44.0 or newer supports using PEM files directly, without the need to use a keystore.
 
-ReadonlyREST can be configured to encrypt network traffic on two independent levels:
-1. HTTP (port 9200)
+Traffic can be encrypted on two independent levels:
+1. HTTP/REST API (port 9200)
 2. Internode communication - transport module (port 9300)
 
-> An Elasticsearch node with ReadonlyREST can join an existing cluster based on native SSL from `xpack.security` module. This configuration is useful to deploy ReadonlyREST Enterprise for Kibana to an existing large production cluster without disrupting any configuration. More on this in the dedicated paragraph of this section.
+#### Choosing between ROR SSL and XPack Security SSL
 
+There are two ways to configure SSL in an Elasticsearch cluster running ReadonlyREST:
+
+- **ROR SSL** — SSL provided by the ReadonlyREST plugin itself (described in the subsections below).
+- **XPack Security SSL** — SSL provided by Elasticsearch's built-in `xpack.security` module.
+
+The choice depends on whether `xpack.security.enabled` is set to `true` or `false` in `elasticsearch.yml`:
+
+| `xpack.security.enabled` | SSL to use |
+|---|---|
+| `false` | ROR SSL |
+| `true` | XPack Security SSL |
+
+**Why does this matter?** During its patching step, ReadonlyREST deactivates XPack Security's authentication and authorization features — these are replaced by ROR's ACL engine. However, **XPack SSL is not deactivated**. This means that when `xpack.security.enabled: true`, XPack SSL is still fully active and must be configured through Elasticsearch's standard mechanism, not through ROR.
+
+> **Recommendation:** Because `xpack.security` enables features used by Elasticsearch and Kibana (e.g. API keys, token service, certain Kibana integrations), it should not be disabled without a clear reason. If there is no specific requirement to disable it, prefer leaving `xpack.security.enabled: true` and use XPack Security SSL.
+
+#### XPack Security SSL (when `xpack.security.enabled: true`)
+
+When `xpack.security.enabled` is `true`, configure SSL by following the official Elasticsearch documentation:
+
+- [Set up basic security (internode TLS)](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html)
+- [Set up basic security plus HTTPS (REST API TLS)](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup-https.html)
+
+ROR's ACL will handle authentication and authorization, while XPack manages the SSL layer transparently.
+
+#### ROR SSL (when `xpack.security.enabled: false`)
+
+The following subsections describe how to configure SSL using ReadonlyREST's own SSL implementation. This applies only when `xpack.security.enabled` is set to `false` in `elasticsearch.yml`.
 
 #### External REST API
 
@@ -489,7 +517,7 @@ Similar to `ssl` for HTTP, the keystore should be stored in the same directory w
 
 ##### Internode communication with XPack nodes
 
-It is possible to set up internode SSL between ROR and XPack nodes. It works only for ES above 6.7.07.0.
+It is possible to set up internode SSL between ROR nodes (with `xpack.security.enabled: false`) and XPack nodes. It works only for ES above 6.7.0.
 
 To set up cluster in such configuration you have to generate certificate for ROR node according to this description https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html#generate-certificates.
 

--- a/examples/elastic-cloud-cluster-integration/details.md
+++ b/examples/elastic-cloud-cluster-integration/details.md
@@ -134,8 +134,6 @@ cluster.name: ror-cluster # the same value used in `instances.yml`
 node.name: ror-es01  # the same value used in `instances.yml`
 network.host: 0.0.0.0
 
-xpack.security.enabled: false
-
 transport.type: ror_ssl_internode
 readonlyrest: # we will put in in `elasticsearch.yml` because each node should have different certificate
   ssl_internode: 

--- a/examples/multitenancy_guide.md
+++ b/examples/multitenancy_guide.md
@@ -48,14 +48,6 @@ For the scope of this guide, we will assume:
 
 If you don't have the ROR [Enterprise](https://readonlyrest.com/enterprise) for Kibana plugin, get yourself a two weeks free trial build!
 
-### IMPORTANT: disable Xpack Security module
-
-Because ReadonlyREST is not compatible with XPack Security module please **make sure you disable xpack.security module from both Kibana and Elasticsearch** by adding the following line to **both** `elasticsearch.yml` and `kibana.yml`:
-
-```yaml
-xpack.security.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-```
-
 ## Setup: the Elasticsearch side
 
 Right beside your `elasticsearch.yml`, create a file called `readonlyrest.yml` and write the following settings into it.

--- a/examples/oidc-sso/keycloak_oidc.md
+++ b/examples/oidc-sso/keycloak_oidc.md
@@ -52,8 +52,6 @@ Then, configure the OpenID Connect (OIDC) client
 # More on how to enable SSL on the official documentation of Kibana
 server.ssl.enabled: false
 
-xpack.security.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-
 elasticsearch:
   hosts: ["https://localhost:9200"] # <-- our Elasticsearch responds to https
   ssl.verificationMode: none

--- a/examples/oidc-sso/keycloak_oidc.md
+++ b/examples/oidc-sso/keycloak_oidc.md
@@ -95,25 +95,12 @@ To provide clientSecret value, you need to open ror\_oidc client (or your custom
 
 ### Setup Elasticsearch with ReadonlyREST
 
-Our elasticsearch can be run with or without SSL. To make it available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)), so we modify the elasticsearch.yml
+Our elasticsearch can be run with or without SSL. To make it available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)).
 
-**append to elasticsearch.yml**
-
-```yaml
-xpack.security.enabled: false
-http.type: ssl_netty4 # <-- needed for ROR SSL
-```
-
-Write in **readonlyrest.yml**
+Then write in **readonlyrest.yml**
 
 ```yaml
 readonlyrest:
-
-    ssl:
-      enable: true
-      keystore_file: "keystore.jks"
-      keystore_pass: readonlyrest
-      key_pass: readonlyrest
 
     audit:
       enabled: true

--- a/examples/saml-sso/adfs.md
+++ b/examples/saml-sso/adfs.md
@@ -525,7 +525,7 @@ It is necessary to make Kibana operate under SSL for AD FS to perform SAML authe
     elasticsearch.username: kibana  # This field matches the first part (pre-colon) of the auth\_key in the readonlyrest.yml Elasticsearch configuration file.
     elasticsearch.password: kibana # This field matches the second part (post-colon) of the auth\_key in the readonlyrest.yml Elasticsearch configuration file.
     elasticsearch.ssl.verificationMode: true # Set the value to “true” to ignore SSL errors. This is useful when working in a test environment.
-    xpack.security.enabled: false # This must be disabled for ReadonlyREST to work. Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
+    
     server.host: 10.0.0.6 # We need to use a routable address, which, in this case, is the 10.0.0.6 IP of this server.
     server.ssl.enabled: true # This is used to turn on SSL and respond to https.
     server.ssl.certificate: '/etc/kibana/ssl_cert/localhost.pem' # This is the location of the public key certificate.

--- a/examples/saml-sso/azure_ad.md
+++ b/examples/saml-sso/azure_ad.md
@@ -57,8 +57,6 @@ readonlyrest:
 **On the Kibana side**, we will now configure our Kibana plugin to speak with Azure AD. Open your `$KBN_HOME/config/kibana.yml`, it should look something like:
 
 ```yaml
-xpack.security.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-
 elasticsearch.hosts: ["http://localhost:9200"] # <-- consider enabling "https" using the SSL feature in ReadonlyREST Free!
 elasticsearch.username: "kibana"
 elasticsearch.password: "kibana"

--- a/examples/saml-sso/keycloak_saml.md
+++ b/examples/saml-sso/keycloak_saml.md
@@ -67,8 +67,6 @@ server.ssl.enabled: true
 server.ssl.key: /home/xx/selfsigned_ssl_localhost/localhost.key
 server.ssl.certificate: /home/xx/selfsigned_ssl_localhost/localhost.crt
 
-xpack.security.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-
 server.basePath: /k  # <-- optional, remember to change it in KC
 elasticsearch:
   hosts: ["https://localhost:9200"] # <-- our Elasticsearch responds to https
@@ -104,7 +102,7 @@ Don't forget setting up SAML requires some changes to security settings in `read
 
 ### Setup Elasticsearch with ReadonlyREST
 
-Our Elasticsearch needs to be available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)). Configure SSL accoring to this guide.
+Our Elasticsearch needs to be available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)). Configure SSL according to this guide.
 
 Then write in **readonlyrest.yml**
 

--- a/examples/saml-sso/keycloak_saml.md
+++ b/examples/saml-sso/keycloak_saml.md
@@ -104,25 +104,12 @@ Don't forget setting up SAML requires some changes to security settings in `read
 
 ### Setup Elasticsearch with ReadonlyREST
 
-Our Elasticsearch needs to be available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)), so we modify the elasticsearch.yml
+Our Elasticsearch needs to be available on HTTPS (more detailed info in our [documentation](../../elasticsearch.md#encryption)). Configure SSL accoring to this guide.
 
-**append to elasticsearch.yml**
-
-```yaml
-xpack.security.enabled: false
-http.type: ssl_netty4 # <-- needed for ROR SSL
-```
-
-Write in **readonlyrest.yml**
+Then write in **readonlyrest.yml**
 
 ```yaml
 readonlyrest:
-
-    ssl:
-      enable: true
-      keystore_file: "keystore.jks"
-      keystore_pass: readonlyrest
-      key_pass: readonlyrest
 
     audit:
       enabled: true

--- a/kibana.md
+++ b/kibana.md
@@ -428,19 +428,7 @@ Now you can restore your settings to `readonlyrest.yml`, remove `readonlyrest.fo
 
 ### Example: multiuser ELK
 
-This configuration will work in PRO and Enterprise editions
-
-Make sure X-Pack is uninstalled or disabled from `elasticsearch.yml` (on the Elasticsearch side) and `kibana.yml` (on the Kibana side): This is how you disable X-pack modules:
-
-```yaml
-# For X-Pack users: you may only leave monitoring on. 
-# Don't add this if X-Pack is not installed at all, or Kibana won't start.
-xpack.monitoring.enabled: true
-xpack.security.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-xpack.watcher.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-xpack.telemetry.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-```
-
+This configuration will work in PRO and Enterprise editions.
 This is a typical example of a configuration snippet to add at the end of your `readonlyrest.yml` (the settings file of the Elasticsearch plugin), to support ReadonlyREST PRO.
 
 ```yaml
@@ -783,13 +771,6 @@ Activate authentication for the Kibana server: let the Kibana daemon connect to 
 Open up `conf/kibana.yml` and add the following:
 
 ```yaml
-# This is kibana.yml, but copy the exact same in elasticsearch.yml if you have to use some X-pack features.
-xpack.graph.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-xpack.ml.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-xpack.monitoring.enabled: true
-xpack.security.enabled: false # this is fundamental! Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-xpack.watcher.enabled: false # Skip this setting in the Kibana configuration for version 8.x, as it has been removed.
-
 # Kibana server use the ::KIBANA-SRV:: basic auth credentials
 elasticsearch.username: "kibana"
 elasticsearch.password: "kibana"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Elasticsearch version requirement to 6.7.0 or newer
  * Simplified installation instructions by removing X-Pack security disabling step
  * Reorganized changelog format for improved readability
  * Enhanced SSL and encryption configuration guidance with clearer setup options
  * Updated integration examples (OIDC, SAML, multitenancy) to reflect simplified setup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->