### PR TITLE
feat(changelog): migrate to per-version YAMLs (66 versions, 518 entries)

### DIFF
--- a/changelog/1.26.0.yaml
+++ b/changelog/1.26.0.yaml
@@ -1,0 +1,3 @@
+version: "1.26.0"
+release_date: "2021-01-02"
+entries:

--- a/changelog/1.26.1.yaml
+++ b/changelog/1.26.1.yaml
@@ -1,0 +1,3 @@
+version: "1.26.1"
+release_date: "2021-01-11"
+entries:

--- a/changelog/1.27.0.yaml
+++ b/changelog/1.27.0.yaml
@@ -1,0 +1,3 @@
+version: "1.27.0"
+release_date: "2021-02-16"
+entries:

--- a/changelog/1.27.1.yaml
+++ b/changelog/1.27.1.yaml
@@ -1,0 +1,3 @@
+version: "1.27.1"
+release_date: "2021-02-27"
+entries:

--- a/changelog/1.28.0.yaml
+++ b/changelog/1.28.0.yaml
@@ -1,0 +1,3 @@
+version: "1.28.0"
+release_date: "2021-03-14"
+entries:

--- a/changelog/1.28.1.yaml
+++ b/changelog/1.28.1.yaml
@@ -1,0 +1,3 @@
+version: "1.28.1"
+release_date: "2021-03-24"
+entries:

--- a/changelog/1.28.2.yaml
+++ b/changelog/1.28.2.yaml
@@ -1,0 +1,3 @@
+version: "1.28.2"
+release_date: "2021-04-01"
+entries:

--- a/changelog/1.29.0.yaml
+++ b/changelog/1.29.0.yaml
@@ -1,0 +1,3 @@
+version: "1.29.0"
+release_date: "2021-04-09"
+entries:

--- a/changelog/1.30.0.yaml
+++ b/changelog/1.30.0.yaml
@@ -1,0 +1,3 @@
+version: "1.30.0"
+release_date: "2021-05-16"
+entries:

--- a/changelog/1.30.1.yaml
+++ b/changelog/1.30.1.yaml
@@ -1,0 +1,3 @@
+version: "1.30.1"
+release_date: "2021-05-26"
+entries:

--- a/changelog/1.31.0.yaml
+++ b/changelog/1.31.0.yaml
@@ -1,0 +1,3 @@
+version: "1.31.0"
+release_date: "2021-06-29"
+entries:

--- a/changelog/1.32.0.yaml
+++ b/changelog/1.32.0.yaml
@@ -1,0 +1,3 @@
+version: "1.32.0"
+release_date: "2021-07-25"
+entries:

--- a/changelog/1.33.0.yaml
+++ b/changelog/1.33.0.yaml
@@ -1,0 +1,3 @@
+version: "1.33.0"
+release_date: "2021-08-09"
+entries:

--- a/changelog/1.33.1.yaml
+++ b/changelog/1.33.1.yaml
@@ -1,0 +1,3 @@
+version: "1.33.1"
+release_date: "2021-08-14"
+entries:

--- a/changelog/1.34.0.yaml
+++ b/changelog/1.34.0.yaml
@@ -1,0 +1,3 @@
+version: "1.34.0"
+release_date: "2021-09-24"
+entries:

--- a/changelog/1.35.0.yaml
+++ b/changelog/1.35.0.yaml
@@ -1,0 +1,3 @@
+version: "1.35.0"
+release_date: "2021-10-12"
+entries:

--- a/changelog/1.35.1.yaml
+++ b/changelog/1.35.1.yaml
@@ -1,0 +1,27 @@
+version: "1.35.1"
+release_date: "2021-10-17"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) & [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)"
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.1"
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.2"
+  - type: enhancement
+    components: [kbn]
+    text: "Support \"server.ssl.supportedProtocols\" settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Support \"server.ssl.cipherSuites\""
+  - type: enhancement
+    components: [kbn]
+    text: "Always honor SSL cipher order"
+  - type: fix
+    components: [kbn]
+    text: "Don'thide \"Add/Remove field as column\" in Discover app for RO users"
+  - type: fix
+    components: [kbn]
+    text: "More alerting fixes (only for main tenancy)"

--- a/changelog/1.36.0.yaml
+++ b/changelog/1.36.0.yaml
@@ -1,0 +1,48 @@
+version: "1.36.0"
+release_date: "2021-11-21"
+entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.16.1, 7.16.0, 6.8.21"
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.2"
+  - type: new
+    components: [es]
+    text: "[Added support for setting up cluster containing ES with ROR (with disabled XPack security) and ES with XPack security enabled](https://forum.readonlyrest.com/t/ssl-internode-with-elk-cluster/1916)"
+  - type: enhancement
+    components: [kbn]
+    text: "kibana_hide_apps: [ror|kibana] to remove kibana mgmt button"
+  - type: fix
+    components: [es]
+    text: "[/_snapshot/_status should return only running snapshots](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/756)"
+  - type: fix
+    components: [es]
+    text: "[Adding policy to index template bug](https://forum.readonlyrest.com/t/forbidden-by-readonlyrest-es-plugin-with-add-policy-to-index-template-action-in-kibana/1969)"
+  - type: fix
+    components: [kbn]
+    text: "Index management tabs result in \"forbidden\" error"
+  - type: fix
+    components: [kbn]
+    text: "[corrupted patch file for Kibana 7.9.x](https://forum.readonlyrest.com/t/ror-1-35-1-kibana-7-9-3-unable-to-patch/2018)"
+  - type: fix
+    components: [kbn]
+    text: "[YAML editor not working in air-gapped environments](https://forum.readonlyrest.com/t/readonlyrest-security-settings-editor-loading/2014/5)"
+  - type: fix
+    components: [kbn]
+    text: "[Devtools not working](https://forum.readonlyrest.com/t/kibana-devtools-error-does-not-support-having-a-body/2027)"
+  - type: fix
+    components: [kbn]
+    text: "[Monitoring not working in multi-tenancy](https://forum.readonlyrest.com/t/kibana-alerting-not-working-with-readonlyrest/1986)"
+  - type: fix
+    components: [kbn]
+    text: "Regression in Kibana < 6.8.x front end crash"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x prevent navigation to hidden apps from home links"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x implicitly hide kibana:dashboard when kibana:dashboards is hidden (and viceversa)"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x broken `clearSessionOnEvents: [tenancyHop]`"

--- a/changelog/1.37.0.yaml
+++ b/changelog/1.37.0.yaml
@@ -1,0 +1,24 @@
+version: "1.37.0"
+release_date: "2021-12-14"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797)"
+  - type: new
+    components: [es]
+    text: "New Support for 7.16.3, 7.16.2, 6.8.23, 6.8.22"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.16.3, 7.16.2, 7.16.1, 7.16.10, 6.8.23, 6.8.22, 6.8.21"
+  - type: enhancement
+    components: [es]
+    text: "fields rule handling in the context of x-Pack SQL requests"
+  - type: fix
+    components: [es]
+    text: "filter rule handling in the context of x-Pack SQL requests"
+  - type: fix
+    components: [kbn]
+    text: "POST / bulk cause an 400 error in devtools console"
+  - type: fix
+    components: [kbn]
+    text: "More robust Kibana patcher + better logs messages"

--- a/changelog/1.38.0.yaml
+++ b/changelog/1.38.0.yaml
@@ -1,0 +1,18 @@
+version: "1.38.0"
+release_date: "2022-01-17"
+entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.17.0, 7.17.1"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.17.0"
+  - type: new
+    components: [es]
+    text: "[Configuration for custom audit cluster](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.38.x/elasticsearch.md#custom-audit-cluster)"
+  - type: enhancement
+    components: [es]
+    text: "Separate \"audit\" section for all audit settings"
+  - type: fix
+    components: [kbn]
+    text: "Editor rendering issue with kibana basePath enabled"

--- a/changelog/1.39.0.yaml
+++ b/changelog/1.39.0.yaml
@@ -1,0 +1,54 @@
+version: "1.39.0"
+release_date: "2022-03-19"
+entries:
+  - type: security
+    components: [kbn]
+    text: "XSS sanitize path requested"
+  - type: security
+    components: [es]
+    text: "[CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) & [CVE-2022-21653](https://nvd.nist.gov/vuln/detail/CVE-2022-21653)"
+  - type: new
+    components: [kbn]
+    text: "New Support for 8.2.0 8.1.3, 8.1.2, 8.1.1, 8.1.0, 8.0.0, 8.0.1, 7.17.3, 7.17.2"
+  - type: new
+    components: [es]
+    text: "New Support for 8.2.0, 8.1.3, 8.1.2, 8.1.1, 8.1.0, 8.0.0, 8.0.1 ([required additional patching step](https://docs.readonlyrest.com/elasticsearch#3.-patch-es))"
+  - type: new
+    components: [es]
+    text: "New Support for 7.17.3, 7.17.2"
+  - type: new
+    components: [es]
+    text: "[New `groups_and` ACL rule](https://docs.readonlyrest.com/elasticsearch#groups_and)"
+  - type: enhancement
+    components: [kbn]
+    text: "Stop inlining whitelisted headers into Authorization header"
+  - type: enhancement
+    components: [kbn]
+    text: "Log additional errors and info related to HA"
+  - type: enhancement
+    components: [kbn]
+    text: "Misc internal dependencies upgrades"
+  - type: fix
+    components: [kbn]
+    text: "Mandatory elasticsearch credentials in kibana.yml"
+  - type: fix
+    components: [kbn]
+    text: "[Reporting page redirect on refresh when kibana_hide_apps: [\"Stack Management\"]](https://forum.readonlyrest.com/t/when-hiding-stack-management-a-redirect-appears-with-report/2088)"
+  - type: fix
+    components: [kbn]
+    text: "whitelistedPaths: log errors when 404 occurs"
+  - type: fix
+    components: [kbn]
+    text: "[Issue uploading large payload](https://forum.readonlyrest.com/t/issue-uploading-large-payload/2091)"
+  - type: fix
+    components: [kbn]
+    text: "`elasticsearch.requestHeadersWhitelist` should be case insensitive"
+  - type: fix
+    components: [es]
+    text: "[Issue with handling data streams by `indices` rule](https://forum.readonlyrest.com/t/ror-1-37-0-indices-rule-and-alias-within-kibana/2078)"
+  - type: fix
+    components: [es]
+    text: "X-Pack SSL nodes cooperation with ROR SSL nodes"
+  - type: fix
+    components: [es]
+    text: "_msearch issue when filter rules was used in matched block"

--- a/changelog/1.40.0.yaml
+++ b/changelog/1.40.0.yaml
@@ -1,0 +1,52 @@
+version: "1.40.0"
+release_date: "2022-05-24"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) & [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823) & [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) & [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) &  [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) & [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518)"
+  - type: security
+    components: [kbn]
+    text: "\"Security\" app not entirely hidden in 8.2.x"
+  - type: new
+    components: [es]
+    text: "New Support for 8.2.3, 8.2.2, 8.2.1, 7.17.4"
+  - type: new
+    components: [kbn]
+    text: "New Support for 8.2.2 8.2.1, 7.17.4"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES & KBN"
+    text: "[The Impersonation feature](https://docs.readonlyrest.com/kibana#impersonation)"
+  - type: new
+    components: [es]
+    text: "[FIPS compliant SSL mode](https://docs.readonlyrest.com/elasticsearch/fips)"
+  - type: enhancement
+    components: [kbn]
+    text: "SAML cert is now required"
+  - type: enhancement
+    components: [kbn]
+    text: "moved OIDC to better library"
+  - type: enhancement
+    components: [kbn]
+    text: "OIDC jwksURL is now required"
+  - type: fix
+    components: [es]
+    text: "`indices: [\"1\"]` interpreted as integer and fails to parse"
+  - type: fix
+    components: [kbn]
+    text: "/login?jwt=xxx authorization now works again"
+  - type: fix
+    components: [kbn]
+    text: "OIDC/SAML assertion claims were not forwarded to ES"
+  - type: fix
+    components: [kbn]
+    text: "include whitelisted headers while logging"
+  - type: fix
+    components: [kbn]
+    text: "basepath handling fixes (too many redirects)"
+  - type: fix
+    components: [kbn]
+    text: "Make ROR default space the actual default one"
+  - type: fix
+    components: [kbn]
+    text: "OIDC connection error"

--- a/changelog/1.41.0.yaml
+++ b/changelog/1.41.0.yaml
@@ -1,0 +1,27 @@
+version: "1.41.0"
+release_date: "2022-06-21"
+entries:
+  - type: new
+    components: [es]
+    text: "Added `groups_and` mode to [`ror_kbn_auth`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_auth) and [`jwt_auth`](https://docs.readonlyrest.com/elasticsearch#jwt_auth) rules"
+  - type: enhancement
+    components: [kbn]
+    text: "Prevent native credentials dialogue to appear in Kibana when ES responds 401"
+  - type: enhancement
+    components: [kbn]
+    text: "Logging in after logout shows the same page you last visited"
+  - type: enhancement
+    components: [kbn]
+    text: "x-ror-correlation-id header lets you audit a whole Kibana session"
+  - type: fix
+    components: [es, kbn]
+    text: "tenancy selector didn't work well with `jwt_auth` and `ror_kbn_auth` rules"
+  - type: fix
+    components: [kbn]
+    text: "Support for special characters in tenancy names"
+  - type: fix
+    components: [kbn]
+    text: "OIDC logout flow redirecting to bad request error"
+  - type: fix
+    components: [kbn]
+    text: "OIDC connector not working in Kibana < 7.12.0"

--- a/changelog/1.42.0.yaml
+++ b/changelog/1.42.0.yaml
@@ -1,0 +1,22 @@
+version: "1.42.0"
+release_date: "2022-07-25"
+entries:
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "8.3.3, 8.3.2, 8.3.1, 8.3.0, 7.15.5 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Search box in tenancy switcher (when #tenancies > 5)"
+  - type: enhancement
+    components: [es]
+    text: "added configuration warnings in the Impersonation Feature"
+  - type: fix
+    components: [kbn]
+    text: "Logout didn't delete the SAML session on the IdP"
+  - type: fix
+    components: [kbn]
+    text: "5xx errors from Elasticsearch break Kibana users' session unrecoverably"
+  - type: fix
+    components: [es]
+    text: "ROR node cooperation with X-pack nodes"

--- a/changelog/1.43.0.yaml
+++ b/changelog/1.43.0.yaml
@@ -1,0 +1,33 @@
+version: "1.43.0"
+release_date: "2022-08-22"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.4.3, 8.4.2, 8.4.1, 8.4.0, 7.17.6 support"
+  - type: new
+    components: [es]
+    text: "8.4.3, 8.4.2, 8.4.1, 8.4.0, 7.17.6 support"
+  - type: new
+    components: [kbn]
+    text: "`kibana_custom_js_inject_file` feature"
+  - type: fix
+    components: [es]
+    text: "[`ror-tools` fix for Windows OS (patching ES 3.x issue)](https://forum.readonlyrest.com/t/ror-plugin-for-es-8-x-patch-error/2115)"
+  - type: fix
+    components: [es]
+    text: "resolving indices in the remote x-pack cluster"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro
+    # original: "* **🐞Fix** (KBN|PRO) ROR menu title wraps when version text is too short (cosmetic)"
+    type: fix
+    components_raw: "KBN|PRO"
+    text: "ROR menu title wraps when version text is too short (cosmetic)"
+  - type: fix
+    components: [kbn]
+    text: "infinite loading when kibana_access not defined for user"
+  - type: fix
+    components: [kbn]
+    text: "transient error with randomly choosing off range bind port on localhost"
+  - type: fix
+    components: [kbn]
+    text: "404 on login when `xpack.spaces.enabled: false`"

--- a/changelog/1.44.0.yaml
+++ b/changelog/1.44.0.yaml
@@ -1,0 +1,42 @@
+version: "1.44.0"
+release_date: "2022-10-09"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-25857](https://nvd.nist.gov/vuln/detail/CVE-2022-25857)"
+  - type: new
+    components: [kbn]
+    text: "8.5.2, 8.5.1, 8.5.0, 7.17.7 support"
+  - type: new
+    components: [es]
+    text: "8.5.2, 8.5.1, 8.5.0, 7.17.7 support"
+  - type: new
+    components: [kbn]
+    text: "**plugin packages are now [universal](https://docs.readonlyrest.com/universal-builds)**"
+  - type: new
+    components: [kbn]
+    text: "**Manage your activation keys through the [customer portal](https://readonlyrest.com/customer)**"
+  - type: new
+    components: [es]
+    text: "Added support for certificates in PEM format"
+  - type: enhancement
+    components: [kbn]
+    text: "SAML groups list duplication made header size exceed limits"
+  - type: enhancement
+    components: [kbn]
+    text: "kibana_access: admin has now privileges to manage a Kibana cluster"
+  - type: enhancement
+    components: [es]
+    text: "added distributed and persistent Test Settings & Auth Mocks configuration for the Impersonation Feature"
+  - type: enhancement
+    components: [es]
+    text: "handling high load when LDAP rules are used"
+  - type: enhancement
+    components: [es]
+    text: "`client_authentication` settings in internode SSL configuration"
+  - type: enhancement
+    components: [es]
+    text: "`acl:available_groups` dynamic variable can be used in a single value context"
+  - type: fix
+    components: [es]
+    text: "SNI handling (internode SSL)"

--- a/changelog/1.45.0.yaml
+++ b/changelog/1.45.0.yaml
@@ -1,0 +1,54 @@
+version: "1.45.0"
+release_date: "2022-11-29"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003), [CVE-2022-45146](https://nvd.nist.gov/vuln/detail/CVE-2022-45146)"
+  - type: new
+    components: [kbn]
+    text: "Activation Key API: read AK from ROR_ACTIVATION_KEY.txt"
+  - type: new
+    components: [kbn]
+    text: "Activation Key API: submit AK via POST /pkp/license (Basic auth)"
+  - type: new
+    components: [kbn]
+    text: "Inject CSS/JS files in login page"
+  - type: new
+    components: [kbn]
+    text: "Add user metadata to <body> for extra UI customization"
+  - type: new
+    components: [es]
+    text: "Added groups_and mode to [groups_provider_authorization](https://docs.readonlyrest.com/elasticsearch#groups_provider_authorization) rule"
+  - type: enhancement
+    components: [es]
+    text: "all authorization rules support wildcards in group IDs"
+  - type: enhancement
+    components: [es]
+    text: "connections in the LDAP pool should not be closed unnecessarily"
+  - type: enhancement
+    components: [kbn]
+    text: "Deterministic reporting index detection"
+  - type: enhancement
+    components: [kbn]
+    text: "Move free type impersonation to the local users area"
+  - type: enhancement
+    components: [kbn]
+    text: "don't logout when initial JWT token expires"
+  - type: fix
+    components: [kbn]
+    text: "Direct Kibana API requests not aware of kibana_index"
+  - type: fix
+    components: [kbn]
+    text: "RO and RO_strict kibana accesses"
+  - type: fix
+    components: [es]
+    text: "[when `fls_engine: es` is configured and `fields` rule is used, aggregations should be available only for allowed fields](https://forum.readonlyrest.com/t/field-level-security-and-aggregations/2133)"
+  - type: fix
+    components: [es]
+    text: "[Data streams creation issue fix](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/829)"
+  - type: fix
+    components: [es]
+    text: "Unknown structure of index settings issue fix"
+  - type: fix
+    components: [es]
+    text: "resolving index names with wildcards should take into consideration the current index state and request indices options"

--- a/changelog/1.45.1.yaml
+++ b/changelog/1.45.1.yaml
@@ -1,0 +1,12 @@
+version: "1.45.1"
+release_date: "2022-12-05"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.5.3, 7.17.8 support"
+  - type: new
+    components: [es]
+    text: "8.5.3, 7.17.8 support"
+  - type: fix
+    components: [kbn]
+    text: "ROR KBN patching script"

--- a/changelog/1.46.0.yaml
+++ b/changelog/1.46.0.yaml
@@ -1,0 +1,36 @@
+version: "1.46.0"
+release_date: "2023-01-02"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471), [CVE-2022-41915](https://nvd.nist.gov/vuln/detail/CVE-2022-41915), [CVE-2022-36944](https://nvd.nist.gov/vuln/detail/CVE-2022-36944) in [audit Scala 2.13 jar](https://mvnrepository.com/artifact/tech.beshu.ror/audit)"
+  - type: new
+    components: [kbn]
+    text: "8.6.1, 8.6.0, 7.17.9 support"
+  - type: new
+    components: [es]
+    text: "8.6.1, 8.6.0, 7.17.9 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Activation key management UI"
+  - type: enhancement
+    components: [kbn]
+    text: "Less verbose logging in info mode"
+  - type: enhancement
+    components: [kbn]
+    text: "\"Stack management\" kibana compatibility"
+  - type: fix
+    components: [kbn]
+    text: "Test settings pop up won't show"
+  - type: fix
+    components: [kbn]
+    text: "hide apps behaviour when \"Management\" is hidden"
+  - type: fix
+    components: [kbn]
+    text: "Data view with a \":\" symbol forces logout from a kibana"
+  - type: fix
+    components: [kbn]
+    text: "Session probe causes constant refresh when no `kibana_access` defined"
+  - type: fix
+    components: [es]
+    text: "large report generation using data from a remote cluster with enabled x-pack security"

--- a/changelog/1.47.0.yaml
+++ b/changelog/1.47.0.yaml
@@ -1,0 +1,36 @@
+version: "1.47.0"
+release_date: "2023-02-13"
+entries:
+  - type: security
+    components: [es]
+    text: "\"/\" endpoint was not protected for ES 8.x"
+  - type: security
+    components: [es]
+    text: "\"/_cat\" endpoint was not protected for all ES versions"
+  - type: new
+    components: [kbn]
+    text: "8.7.0, 8.6.2 support"
+  - type: new
+    components: [es]
+    text: "8.7.0, 8.6.2 support"
+  - type: new
+    components: [es]
+    text: "[the `data_streams` rule](https://docs.readonlyrest.com/v/develop/elasticsearch#data_streams)"
+  - type: enhancement
+    components: [kbn]
+    text: "optimisation in hidden apps feature"
+  - type: fix
+    components: [kbn]
+    text: "Opening index management mappings tab forces logout"
+  - type: fix
+    components: [kbn]
+    text: "Fix dark mode in the ROR menu"
+  - type: fix
+    components: [kbn]
+    text: "YAML editor updates and fixes"
+  - type: fix
+    components: [es]
+    text: "Data streams support in the `indices` rule"
+  - type: fix
+    components: [es]
+    text: "NPE when `_search` with aggregations (script) and the `fields` rule were used together"

--- a/changelog/1.48.0.yaml
+++ b/changelog/1.48.0.yaml
@@ -1,0 +1,71 @@
+version: "1.48.0"
+release_date: "2023-04-15"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-45688](https://nvd.nist.gov/vuln/detail/CVE-2022-45688)"
+  - type: new
+    components: [kbn]
+    text: "8.7.1, 7.17.10 support"
+  - type: new
+    components: [es]
+    text: "8.8.0, 8.7.1, 7.17.10 support"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[Introducing \"Custom Middleware\" functionality](https://docs.readonlyrest.com/kibana#custom-middleware)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[`allowed_api_paths` support in the `kibana` ACL rule](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules)"
+  - type: new
+    components: [kbn]
+    text: "Add CSRF protection in the login form"
+  - type: new
+    components: [kbn]
+    text: "Restore deprecated \"kibana.index\" support for Kibana > 8.x"
+  - type: new
+    components: [es]
+    text: "[all Kibana-related rules are gathered in one, new `kibana` ACL rule](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules)"
+  - type: new
+    components: [es]
+    text: "[audit supports a new output type: `log`](https://docs.readonlyrest.com/elasticsearch/audit)"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to disable multi-tenancy in ROR Enterprise"
+  - type: enhancement
+    components: [kbn]
+    text: "Realign index templates behaviour to the old platform"
+  - type: enhancement
+    components: [kbn]
+    text: "Error logs when SAML obtains an unusable username from the assertion"
+  - type: enhancement
+    components: [kbn]
+    text: "Test configuration warnings improvement"
+  - type: enhancement
+    components: [es]
+    text: "[Added support to override default response code for not started ROR](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/794)"
+  - type: fix
+    components: [kbn]
+    text: "Security card not hidden by default"
+  - type: fix
+    components: [kbn]
+    text: "Hidden apps regex with two \"or\" operators don't hide all kibana apps"
+  - type: fix
+    components: [kbn]
+    text: "Fix Alerting Rules resulting in logout issue"
+  - type: fix
+    components: [kbn]
+    text: "Fix audit dashboard"
+  - type: fix
+    components: [kbn]
+    text: "Stop handling 500 error from `api/lens/existing_fields`"
+  - type: fix
+    components: [kbn]
+    text: "Fix lens app"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn < 7.9.x
+    # original: "* **🐞Fix** (KBN < 7.9.x) using a custom kibana index in cooperation with ROR Free"
+    type: fix
+    components_raw: "KBN < 7.9.x"
+    text: "using a custom kibana index in cooperation with ROR Free"

--- a/changelog/1.49.0.yaml
+++ b/changelog/1.49.0.yaml
@@ -1,0 +1,36 @@
+version: "1.49.0"
+release_date: "2023-05-28"
+entries:
+  - type: new
+    components: [es]
+    text: "8.8.1 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Handle `elasticsearch.serviceAccountSupport` configuration property"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to Hidden apps Stack management items hiding"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide an automated migration of tenancy indices on major Kibana version upgrade"
+  - type: enhancement
+    components: [es]
+    text: "external group ID patterns support in the external to local groups mapping"
+  - type: fix
+    components: [kbn]
+    text: "the issue with the replica number being set to 0 on tenant index creation"
+  - type: fix
+    components: [kbn]
+    text: "users won't log out from Kibana on the 500 status error"
+  - type: fix
+    components: [kbn]
+    text: "the issue with Kibana keystore not being read by the Kibana plugin"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn < 7.9.0
+    # original: "* **🐞Fix** (KBN < 7.9.0) logging issue when two Kibanas are handled by one browser at the same time"
+    type: fix
+    components_raw: "KBN < 7.9.0"
+    text: "logging issue when two Kibanas are handled by one browser at the same time"
+  - type: fix
+    components: [es]
+    text: "resolving ENVs to YAML number in ROR settings"

--- a/changelog/1.49.1.yaml
+++ b/changelog/1.49.1.yaml
@@ -1,0 +1,27 @@
+version: "1.49.1"
+release_date: "2023-06-27"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976)"
+  - type: security
+    components: [es]
+    text: "[CVE-2023-34462](https://github.com/advisories/GHSA-6mjq-h674-j845)"
+  - type: new
+    components: [kbn]
+    text: "8.8.2, 8.8.1, 8.8.0, 7.17.11 support"
+  - type: new
+    components: [es]
+    text: "8.8.2, 7.17.11 support"
+  - type: new
+    components: [es]
+    text: "[LDAP nested groups support](https://docs.readonlyrest.com/elasticsearch#ldap-connector)"
+  - type: enhancement
+    components: [kbn]
+    text: "[Allow setting default tenancy via `/login?defaultGroup` query param. To be used with \"Custom Middleware\" feature for reordering available tenancies in the ROR menu](https://docs.readonlyrest.com/examples/custom-middleware/reordering-available-tenancies)"
+  - type: fix
+    components: [es]
+    text: "[Fix for ES warnings in logs about custom action names (ROR internal actions)](https://forum.readonlyrest.com/t/invalid-action-name-cluster-ror-audit-event-put/2186)"
+  - type: fix
+    components: [es]
+    text: "[kibana access `rw` and `admin` should allow to manage component templates](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372)"

--- a/changelog/1.50.0.yaml
+++ b/changelog/1.50.0.yaml
@@ -1,0 +1,25 @@
+version: "1.50.0"
+release_date: "2023-07-25"
+entries:
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "ECK support"
+  - type: new
+    components: [kbn]
+    text: "8.9.1, 8.9.0, 7.17.12 support"
+  - type: new
+    components: [es]
+    text: "8.9.1, 8.9.0, 7.17.12 support"
+  - type: new
+    components: [kbn]
+    text: "Introduce the new ReadonlyREST API"
+  - type: enhancement
+    components: [kbn]
+    text: "Remove application item info from URL on the tenant switch to avoid a 404 not found message"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide Reordering available tenancies for proxy auth authentication"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide information about granted/rejected log-in users to debug logs"

--- a/changelog/1.51.0.yaml
+++ b/changelog/1.51.0.yaml
@@ -1,0 +1,39 @@
+version: "1.51.0"
+release_date: "2023-09-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "the issue with [api_only](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules) access level user and accessing via Kibana UI"
+  - type: new
+    components: [kbn]
+    text: "8.10.2, 8.10.1, 8.9.2, 7.17.13 support"
+  - type: new
+    components: [es]
+    text: "8.10.2, 8.10.1, 8.10.0, 8.9.2, 7.17.13 support"
+  - type: new
+    components: [es]
+    text: "[Dynamic variables transformation support](https://docs.readonlyrest.com/elasticsearch#variables-functions)"
+  - type: enhancement
+    components: [kbn]
+    text: "Expose interactive Swagger as a new Security settings tab"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide detailed information about the invalid activation key"
+  - type: enhancement
+    components: [es]
+    text: "additional `hide_apps` validation in the `kibana` rule"
+  - type: fix
+    components: [kbn]
+    text: "the issue with the persistence of an activation key provided via UI when `readonlyrest_kbn.cookiePass` was not provided. The [readonlyrest_kbn.cookiePass](https://docs.readonlyrest.com/kibana#configuring-kibana) is required `kibana.yml` property"
+  - type: fix
+    components: [kbn]
+    text: "issues for Kibana versions between 7.9.0 and 7.10.2, related to the activation key, Spaces, and readonlyREST menu crash"
+  - type: fix
+    components: [kbn]
+    text: "The issue with a logout from Kibana when the link to the Kibana is open from a third-party application like `Gmail`"
+  - type: fix
+    components: [es]
+    text: "[getting data streams when not full names of backing indices are declared in the `indices` rule](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372/7)"
+  - type: fix
+    components: [es]
+    text: "stack-management screen fix in case of `xpack.security.enabled: true`"

--- a/changelog/1.51.1.yaml
+++ b/changelog/1.51.1.yaml
@@ -1,0 +1,21 @@
+version: "1.51.1"
+release_date: "2023-09-25"
+entries:
+  - type: security
+    components: [es]
+    text: "[`fields` rule didn't work well in the case of ES 7.10.0 and later and more than 10 documents in the response](https://forum.readonlyrest.com/t/field-rule-not-working-when-exceeding-a-certain-no-of-docs/2415)"
+  - type: fix
+    components: [kbn]
+    text: "issue with Observability Overview-based applications hiding"
+  - type: fix
+    components: [kbn]
+    text: "Correct `kibana.index` handling for KBN >= 7.9.0 when multi-tenancy is disabled or unavailable"
+  - type: fix
+    components: [kbn]
+    text: "Unrestricted Kibana Access on the tenancy switch when a selected tenant is not available anymore"
+  - type: fix
+    components: [kbn]
+    text: "Unhandled error during login when `multiTenancyEnabled: false`"
+  - type: fix
+    components: [es]
+    text: "LDAP connectivity improvements"

--- a/changelog/1.52.0.yaml
+++ b/changelog/1.52.0.yaml
@@ -1,0 +1,36 @@
+version: "1.52.0"
+release_date: "2023-10-09"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-4586](https://access.redhat.com/security/cve/cve-2023-4586)"
+  - type: new
+    components: [kbn]
+    text: "8.10.4, 8.10.3, 7.17.15, 7.17.14 support"
+  - type: new
+    components: [es]
+    text: "8.10.4, 8.10.3, 7.17.15, 7.17.14 support"
+  - type: new
+    components: [es]
+    text: "[New `token_authentication` rule](https://docs.readonlyrest.com/elasticsearch#token_authentication)"
+  - type: enhancement
+    components: [kbn]
+    text: "Permanently hide Kibana|ES features that are impossible to support"
+  - type: enhancement
+    components: [kbn]
+    text: "[License expiration reminder](https://forum.readonlyrest.com/t/license-expiration-reminder/2417)"
+  - type: enhancement
+    components: [kbn]
+    text: "Make `kibana.index` setting from kibana.yml an invalid property for an Enterprise user"
+  - type: fix
+    components: [kbn]
+    text: "Issue with not adding `elasticsearch.customHeaders` setting from kibana.yml to ROR requests"
+  - type: fix
+    components: [kbn]
+    text: "Logout after opening Stack management Upgrading assistant"
+  - type: fix
+    components: [kbn]
+    text: "Problem with logging in of two users in two tabs when two Kibana instances are used"
+  - type: fix
+    components: [kbn]
+    text: "Problem with logging in when multi-tenancy is enabled and the `indices` rule is defined in the ROR settings"

--- a/changelog/1.53.0.yaml
+++ b/changelog/1.53.0.yaml
@@ -1,0 +1,36 @@
+version: "1.53.0"
+release_date: "2023-11-20"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-4586](https://nvd.nist.gov/vuln/detail/CVE-2023-4586), [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072)"
+  - type: new
+    components: [kbn]
+    text: "8.11.3, 8.11.2, 8.11.1, 8.11.0, 7.17.16 support"
+  - type: new
+    components: [es]
+    text: "8.11.3, 8.11.2, 8.11.1, 8.11.0, 7.17.16 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide Activate license endpoint to the ReadonlyREST API"
+  - type: enhancement
+    components: [es]
+    text: "[when the `kibana` rule and the `indices` rule are defined in the same block](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#index), there is no need to explicitly allow kibana-related indices"
+  - type: fix
+    components: [kbn]
+    text: "problem with reports generation when `kibana.index` in kibana.yml is used"
+  - type: fix
+    components: [kbn]
+    text: "crash loop during license service initialization"
+  - type: fix
+    components: [kbn]
+    text: "problem with logging in in KBN 7.17.13 (and above) and 8.10.4 (and above) when deployed using ECK"
+  - type: fix
+    components: [kbn]
+    text: "[problem with multi-tenancy and ECK](https://forum.readonlyrest.com/t/multi-tanancy-issue/2427)"
+  - type: fix
+    components: [kbn]
+    text: "problem with forbidden `/_create/config` response on Login to the Kibana"
+  - type: fix
+    components: [es]
+    text: "[patching fix, when a non-default ES path is used (e.g. on K8s)](https://forum.readonlyrest.com/t/getting-java-lang-illegalargumentexception-when-initializing-ror-in-es-8-10-4/2441)"

--- a/changelog/1.54.0.yaml
+++ b/changelog/1.54.0.yaml
@@ -1,0 +1,27 @@
+version: "1.54.0"
+release_date: "2023-12-17"
+entries:
+  - type: security
+    components: [es]
+    text: "[Scroll API: protected data could leak when the `fields` rule was used with `fls_engine` set to `es` or `es_with_lucene`](https://forum.readonlyrest.com/t/field-rule-not-working-when-exceeding-a-certain-no-of-docs/2415/7)"
+  - type: new
+    components: [kbn]
+    text: "8.12.0, 8.11.4 support"
+  - type: new
+    components: [es]
+    text: "8.12.0, 8.11.4, 7.17.17 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide automatic [cleaning of stale sessions](https://docs.readonlyrest.com/kibana#automatic-session-cleanup)"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide automatic cleaning of stale CSRF cookies"
+  - type: fix
+    components: [kbn]
+    text: "Adjust the ROR API POST license endpoint body to the contract to respect the `license` body parameter instead of a `token`"
+  - type: fix
+    components: [kbn]
+    text: "`CorelationId`` is changed on every session refresh"
+  - type: fix
+    components: [es]
+    text: "[\"missing authorization info\" problem in some situations when `xpack.security.enabled` was configured to be `true`](https://forum.readonlyrest.com/t/diana-eck/2298/75)"

--- a/changelog/1.55.0.yaml
+++ b/changelog/1.55.0.yaml
@@ -1,0 +1,30 @@
+version: "1.55.0"
+release_date: "2024-01-29"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-51074](https://nvd.nist.gov/vuln/detail/CVE-2023-51074)"
+  - type: new
+    components: [kbn]
+    text: "8.12.2 ,8.12.1, 7.17.18, 7.17.17 support"
+  - type: new
+    components: [es]
+    text: "8.12.2, 8.12.1, 7.17.18 support"
+  - type: new
+    components: [es]
+    text: "[Elasticsearch images with preinstalled ReadonlyREST plugin in Docker Hub](https://hub.docker.com/r/beshultd/elasticsearch-readonlyrest)"
+  - type: enhancement
+    components: [kbn]
+    text: "Optional `readonlyrest_kbn.auth.oidc_kc.proxyURL` kibana.yml configuration for the OIDC connection which allows declaring your proxy URL"
+  - type: enhancement
+    components: [kbn]
+    text: "Upon successful activation and edition changes all sessions are cleared and users are logged out"
+  - type: fix
+    components: [kbn]
+    text: "Saved objects are not visible for the users on Kibana >= 8.8.0"
+  - type: fix
+    components: [es]
+    text: "[LDAP nested group IDs are properly escaped](https://forum.readonlyrest.com/t/support-kbn-ent-ldap-and-parentheses/2466)"
+  - type: fix
+    components: [es]
+    text: "Logout when a user with restricted `kibana.access` tried to see a restoration status of snapshots in Kibana"

--- a/changelog/1.56.0.yaml
+++ b/changelog/1.56.0.yaml
@@ -1,0 +1,48 @@
+version: "1.56.0"
+release_date: "2024-03-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "Provide a way to switch light/dark mode per user"
+  - type: new
+    components: [kbn]
+    text: "8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support"
+  - type: new
+    components: [es]
+    text: "8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support"
+  - type: warning
+    components: [es]
+    text: "[for ES > 6.5 patching is required since this version of ROR](https://docs.readonlyrest.com/elasticsearch#id-5.-patch-elasticsearch)"
+  - type: enhancement
+    components: [kbn]
+    text: "The activation key will be revalidated in the interval"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to define Activation key [retrieval mode](https://docs.readonlyrest.com/v/develop/universal-builds#change-activation-key-retrieval-mode-via-kibana.yml)"
+  - type: fix
+    components: [kbn]
+    text: "Sometimes reports are not generated correctly for Kibana >= 8.0.0 and \"Max attempt reached\" error  appears"
+  - type: fix
+    components: [kbn]
+    text: "The OIDC scope configuration property was not applied and the default configuration was used instead."
+  - type: fix
+    components: [kbn]
+    text: "The OIDC proxy parameter was not handled properly in case of HTTPs connection over HTTP proxy server"
+  - type: fix
+    components: [kbn]
+    text: "Missing information when Kibana is not patched"
+  - type: fix
+    components: [es]
+    text: "[Repositories and Snapshots handling by ES coordinating nodes](https://forum.readonlyrest.com/t/snapshot-status-cannot-modify-incoming-request/2471)"
+  - type: fix
+    components: [es]
+    text: "[Internode SSL `certificate_verification: true` was causing problems with nodes discovery](https://forum.readonlyrest.com/t/upgrade-elasticsearch-8-2-to-8-x-leads-to-ssl-problems/2480)"
+  - type: fix
+    components: [es]
+    text: "Missing `x-elastic-product` header in the response when `fields` and `filter` rules were used"
+  - type: fix
+    components: [es]
+    text: "Proper `forbid` policy handling during processing ROR login request"
+  - type: fix
+    components: [es]
+    text: "`application/nd-json` media type handling (in case of ES `7.x` versions)"

--- a/changelog/1.57.0.yaml
+++ b/changelog/1.57.0.yaml
@@ -1,0 +1,55 @@
+version: "1.57.0"
+release_date: "2024-04-28"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-29025](https://nvd.nist.gov/vuln/detail/CVE-2024-29025)"
+  - type: new
+    components: [es]
+    text: "[LDAP Connector](https://docs.readonlyrest.com/elasticsearch#configuration-notes) feature: groups server-side filtering"
+  - type: new
+    components: [es]
+    text: "[LDAP Connector](https://docs.readonlyrest.com/elasticsearch#configuration-notes) feature: skip user search option when user attribute is `cn`"
+  - type: warning
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "Internal API incompatibilities (to take advantage of rolling update capabilities, upgrade ROR KBN first)"
+  - type: warning
+    components: [es]
+    text: "Support for ES < 6.8.0 was dropped"
+  - type: enhancement
+    components: [kbn]
+    text: "User settings available for all access type users"
+  - type: enhancement
+    components: [kbn]
+    text: "Add option to change the Default Route and Time zone in User settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide correlation ID to Kibana logs"
+  - type: enhancement
+    components: [es]
+    text: "Rich, context-based debug logging in the LDAP connector and LDAP-related rules"
+  - type: enhancement
+    components: [es]
+    text: "Additional [validations](https://docs.readonlyrest.com/elasticsearch#configuring-an-acl-with-filter-fields-rules-when-using-kibana): `kibana` rule should not be used with some other rules in the same block"
+  - type: fix
+    components: [kbn]
+    text: "Sometimes reports are not generated correctly for Kibana < 8.0.0 and the \"Max attempt reached\" error appears"
+  - type: fix
+    components: [kbn]
+    text: "Adjust interactive API swagger dark mode colors"
+  - type: fix
+    components: [kbn]
+    text: "CSRF problem when multiple ECK Kibana instances"
+  - type: fix
+    components: [kbn]
+    text: "Plugin doesn't run for a version Kibana < 7.11.0 when the OIDC proxy is enabled"
+  - type: fix
+    components: [kbn]
+    text: "Session probe should log out the user when empty metadata was returned from ES ROR"
+  - type: fix
+    components: [es]
+    text: "Misc issues when `xpack.security.enabled: true` is set"
+  - type: fix
+    components: [es]
+    text: "Patched files permission issue"

--- a/changelog/1.57.1.yaml
+++ b/changelog/1.57.1.yaml
@@ -1,0 +1,6 @@
+version: "1.57.1"
+release_date: "2024-04-29"
+entries:
+  - type: fix
+    components: [es]
+    text: "configuration parsing regression: one group definition can be a string"

--- a/changelog/1.57.2.yaml
+++ b/changelog/1.57.2.yaml
@@ -1,0 +1,21 @@
+version: "1.57.2"
+release_date: "2024-05-05"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.13.4, 8.13.3, 7.17.21 support"
+  - type: new
+    components: [es]
+    text: "8.13.4, 8.13.3, 7.17.21 support"
+  - type: fix
+    components: [kbn]
+    text: "Kibana <= 7.2.1 doesn't run"
+  - type: fix
+    components: [kbn]
+    text: "Provides a way to migrate an existing session index to the new session"
+  - type: fix
+    components: [es]
+    text: "[Patching issue for Elasticsearch installed from packages](https://forum.readonlyrest.com/t/bootstrap-error-es/2574)"
+  - type: fix
+    components: [es]
+    text: "Patching issue for Elasticsearch OSS versions"

--- a/changelog/1.57.3.yaml
+++ b/changelog/1.57.3.yaml
@@ -1,0 +1,18 @@
+version: "1.57.3"
+release_date: "2024-05-18"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-34447](https://nvd.nist.gov/vuln/detail/CVE-2024-34447)"
+  - type: new
+    components: [kbn]
+    text: "8.14.1, 8.14.0, 7.17.22 support"
+  - type: new
+    components: [es]
+    text: "8.14.1, 8.14.0, 7.17.22 support"
+  - type: fix
+    components: [kbn]
+    text: "The CSRF cookie name issue that caused the \"Wrong credentials\" error during login"
+  - type: fix
+    components: [kbn]
+    text: "Automatic migration issue for Kibana >= 8.8.0 that caused the \"mapping set to strict, dynamic introduction of... error"

--- a/changelog/1.58.0.yaml
+++ b/changelog/1.58.0.yaml
@@ -1,0 +1,36 @@
+version: "1.58.0"
+release_date: "2024-06-30"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2022-39353](https://www.cve.org/CVERecord?id=CVE-2022-39353), [CVE-2020-7753](https://www.cve.org/CVERecord?id=CVE-2020-7753), [CVE-2022-37616](https://www.cve.org/CVERecord?id=CVE-2022-37616), [CVE-2024-29041](https://www.cve.org/CVERecord?id=CVE-2024-29041), [CVE-2022-0691](https://www.cve.org/CVERecord?id=CVE-2022-0691), [CVE-2021-3801](https://www.cve.org/CVERecord?id=CVE-2021-3801), [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883), [CVE-2022-0512](https://www.cve.org/CVERecord?id=CVE-2022-0512), [CVE-2022-0686](https://www.cve.org/CVERecord?id=CVE-2022-0686), [CVE-2022-0639](https://www.cve.org/CVERecord?id=CVE-2022-0639), [CVE-2022-25881](https://www.cve.org/CVERecord?id=CVE-2022-25881), [CVE-2023-0842](https://www.cve.org/CVERecord?id=CVE-2023-0842), [CVE-2017-16137](https://www.cve.org/CVERecord?id=CVE-2017-16137), [CVE-2022-33987](https://www.cve.org/CVERecord?id=CVE-2022-33987), [CVE-2022-23647](https://www.cve.org/CVERecord?id=CVE-2022-23647), [CVE-2022-36083](https://www.cve.org/CVERecord?id=CVE-2022-36083), [CVE-2024-28176](https://www.cve.org/CVERecord?id=CVE-2024-28176)"
+  - type: new
+    components: [kbn]
+    text: "[Kibana images with preinstalled ReadonlyREST plugin in Docker Hub](https://hub.docker.com/r/beshultd/kibana-readonlyrest)"
+  - type: new
+    components: [kbn]
+    text: "8.14.3, 8.14.2 support"
+  - type: new
+    components: [es]
+    text: "8.14.3, 8.14.2 support"
+  - type: new
+    components: [es]
+    text: "[\"structured groups\" feature](https://github.com/beshu-tech/readonlyrest-docs/blob/develop/details/structured-groups.md) (authorization rules group names and group IDs can be defined separately)"
+  - type: enhancement
+    components: [kbn]
+    text: "New `readonlyrest_kbn.cookies.secure` and `readonlyrest_kbn.cookies.sameSite` cookie settings via kibana.yml"
+  - type: enhancement
+    components: [es]
+    text: "improved error logging on the creation of LDAP connectors"
+  - type: enhancement
+    components: [es]
+    text: "Patcher - invalid state after patching detection improvements"
+  - type: fix
+    components: [kbn]
+    text: "Impersonation and session probe logout issue"
+  - type: fix
+    components: [kbn]
+    text: "[Problem with the number of replicas and index template, where the number of replicas was always set to 1. Now, the default value will be the same, as in the case of the Kibana index](https://forum.readonlyrest.com/t/0-replicas-for-single-node-clusters/2530)"
+  - type: fix
+    components: [kbn]
+    text: "Fix problem with multi-tenancy features when xpack.security.enabled: true"

--- a/changelog/1.59.0.yaml
+++ b/changelog/1.59.0.yaml
@@ -1,0 +1,24 @@
+version: "1.59.0"
+release_date: "2024-08-01"
+entries:
+  - type: new
+    components: [es]
+    text: "8.15.1, 8.15.0, 7.17.24, 7.17.23, 6.7.x support"
+  - type: new
+    components: [kbn]
+    text: "8.15.1, 8.15.0, 7.17.24, 7.17.23 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Replace a broken Alert and Connectors applications with the link to our [new tool](https://anaphora.it) for Reports and alerting for Kibana > 8.6.0 (edited)"
+  - type: fix
+    components: [kbn]
+    text: "Handling reporting URL for report generation"
+  - type: fix
+    components: [kbn]
+    text: "Embedding with inline JWT is a feature available only in ReadonlyREST PRO and Enterprise"
+  - type: fix
+    components: [es]
+    text: "[Patcher `UnsupportedOperationException` issue on Windows](https://forum.readonlyrest.com/t/ror-1-58-0-for-es8-14-3-windows-setup/2577)"
+  - type: fix
+    components: [es]
+    text: "for the problem with `_async_search` on ES 8.14.x"

--- a/changelog/1.60.0.yaml
+++ b/changelog/1.60.0.yaml
@@ -1,0 +1,40 @@
+version: "1.60.0"
+release_date: "2024-09-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.15.3, 8.15.2, 7.17.25 support"
+  - type: new
+    components: [es]
+    text: "8.15.3, 8.15.2, 7.17.25 support"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "[ECK support documentation](https://docs.readonlyrest.com/eck)"
+  - type: new
+    components: [es]
+    text: "configurable ROR YAML settings max size"
+  - type: warning
+    components: [es]
+    text: "The prompt for basic authorization is disabled by default. To keep the previous behavior, set `readonlyrest.prompt_for_basic_auth` to `true` in the ROR configuration"
+  - type: enhancement
+    components: [kbn]
+    text: "There is an option to define [client authentication methods](https://docs.readonlyrest.com/kibana#client-authentication-methods) in the `kibana.yml` via `readonlyrest_kbn.auth.<YOUR_OIDC_CONFIG>.tokenEndpointAuthMethod`, 'client_secret_post' or ''client_secret_basic'"
+  - type: enhancement
+    components: [kbn]
+    text: "Stop Kibana when enabled features are not available"
+  - type: fix
+    components: [kbn]
+    text: "HTTP 400 (bad request) issue when there is a Nginx proxy server between es and Kibana"
+  - type: fix
+    components: [kbn]
+    text: "Fix for the problem with correctly hiding Management features `ROR Manage Kibana` defined in the readonlyrest.yml `kibana_hide_apps` property"
+  - type: fix
+    components: [es]
+    text: "ROR KBN docker image: passing ROR settings as ENVs fixes"
+  - type: fix
+    components: [es]
+    text: "[Data stream backing indices access issue with the indices rule](https://forum.readonlyrest.com/t/requested-index-doesnt-exist/2573)"
+  - type: fix
+    components: [es]
+    text: "[Fix for the problem with remote access to data stream aliases](https://forum.readonlyrest.com/t/requested-index-doesnt-exist/2573)"

--- a/changelog/1.61.0.yaml
+++ b/changelog/1.61.0.yaml
@@ -1,0 +1,57 @@
+version: "1.61.0"
+release_date: "2024-11-12"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764)"
+  - type: warning
+    components: [kbn]
+    text: "Acknowledgement needs to be accepted before a Kibana patching process. For scripts, you can [set a flag](https://docs.readonlyrest.com/kibana#patching-kibana) to automate a process (edited)"
+  - type: new
+    components: [kbn]
+    text: "8.15.4 support"
+  - type: new
+    components: [es]
+    text: "8.16.0, 8.15.4 support"
+  - type: new
+    components: [es]
+    text: "There is an option to define [a custom response for users in ACL block with the 'forbid' policy](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration)"
+  - type: enhancement
+    components: [kbn]
+    text: "Set-Cookie is not returned with KBN API response"
+  - type: enhancement
+    components: [kbn]
+    text: "Reduce the amount of ReadonlyREST session updates"
+  - type: enhancement
+    components: [kbn]
+    text: "Kibana plugin won't start until the connection with Elasticsearch is established"
+  - type: enhancement
+    components: [kbn]
+    text: "API and activation key tabs in the Security settings are visible only for the admin or unrestricted access users"
+  - type: enhancement
+    components: [kbn]
+    text: "detecting issues related to high disk watermark warning"
+  - type: enhancement
+    components: [kbn]
+    text: "License expiration info only for admin and unrestricted access users"
+  - type: enhancement
+    components: [es]
+    text: "index exclusion (dash) syntax support"
+  - type: fix
+    components: [kbn]
+    text: "Don't stop Kibana when correlationId is not available in the session"
+  - type: fix
+    components: [kbn]
+    text: "Provide additional [SAML configuration options](https://docs.readonlyrest.com/kibana#usage-with-active-directory-federation-services) to handle Active Directory Federation Services (ADFS) properly"
+  - type: fix
+    components: [kbn]
+    text: "login page customization should be a PRO feature instead of an Enterprise"
+  - type: fix
+    components: [kbn]
+    text: "Logging to file doesn't work for Kibana 8.x"
+  - type: fix
+    components: [es]
+    text: "Snapshot Status API - forbidden response while checking the status of all snapshots of the given repository"
+  - type: fix
+    components: [es]
+    text: "Snapshot API - misc issues for ES 6.x"

--- a/changelog/1.61.1.yaml
+++ b/changelog/1.61.1.yaml
@@ -1,0 +1,24 @@
+version: "1.61.1"
+release_date: "2024-11-20"
+entries:
+  - type: security
+    components: [es]
+    text: "[Data leak through the ESQL API](https://forum.readonlyrest.com/t/eql-requests-returns-data-even-though-they-aren-t-allowed/2679) (for ES >= 8.11.0)"
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-21538](https://www.cve.org/CVERecord?id=CVE-2024-21538), [CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-47535](https://nvd.nist.gov/vuln/detail/CVE-2024-47535)"
+  - type: new
+    components: [kbn]
+    text: "8.17.0, 8.16.2, 8.16.1, 8.16.0, 8.15.5, 7.17.27, 7.17.26 support"
+  - type: new
+    components: [es]
+    text: "8.17.0, 8.16.2, 8.16.1, 8.15.5, 7.17.27, 7.17.26 support"
+  - type: new
+    components: [es]
+    text: "ESQL support"
+  - type: fix
+    components: [kbn]
+    text: "Elasticsearch red status shouldn't kill the Kibana process on initialization"

--- a/changelog/1.62.0.yaml
+++ b/changelog/1.62.0.yaml
@@ -1,0 +1,48 @@
+version: "1.62.0"
+release_date: "2025-01-24"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-53990](https://nvd.nist.gov/vuln/detail/CVE-2024-53990)"
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-21538](https://www.cve.org/CVERecord?id=CVE-2024-21538), [CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764), [CVE-2024-52798](https://www.cve.org/CVERecord?id=CVE-2024-52798)"
+  - type: warning
+    components: [kbn]
+    text: "Updated [`readonlyrest_kbn: license: activationKeyRefreshInterval`](https://forum.readonlyrest.com/t/restricting-access-to-some-spaces/2633/4) - the maximum refresh interval is now set to 1 day."
+  - type: new
+    components: [es, kbn]
+    text: "Introduced support for [Elastic APM (Application Performance Monitoring)](https://www.elastic.co/observability/application-performance-monitoring)."
+  - type: new
+    components: [kbn]
+    text: "8.17.3, 8.17.2, 8.17.1, 8.16.5, 8.16.4, 8.16.3, 7.17.28 support"
+  - type: new
+    components: [es]
+    text: "8.17.3, 8.17.2, 8.17.1, 8.16.5, 8.16.4, 8.16.3, 7.17.28 support"
+  - type: new
+    components: [kbn]
+    text: "Added [Kibana images with the preinstalled ReadonlyREST plugin for the arm64 platform](https://hub.docker.com/r/beshultd/kibana-readonlyrest) on Docker Hub."
+  - type: new
+    components: [es]
+    text: "Added [Elasticsearch images with the preinstalled ReadonlyREST plugin for the arm64 platform](https://hub.docker.com/r/beshultd/elasticsearch-readonlyrest) on Docker Hub."
+  - type: enhancement
+    components: [es]
+    text: "[Introduced validation to prevent multiple username entries in the users section.](https://forum.readonlyrest.com/t/ror-1-57-3-es-8-13-2-double-usernames-allowed/2621/2)"
+  - type: fix
+    components: [kbn]
+    text: "[Resolved an issue with exit patching-based commands.](https://forum.readonlyrest.com/t/restricting-access-to-some-spaces/2633/6)"
+  - type: fix
+    components: [kbn]
+    text: "Addressed a bug in Kibana 8.16.0 and later versions to hide the permissions tab in a space."
+  - type: fix
+    components: [kbn]
+    text: "Fixed a compatibility issue where OIDC and SAML didn't work in Kibana versions earlier than 7.11.0."
+  - type: fix
+    components: [kbn]
+    text: "Ensured user settings are overridden only for the default space."
+  - type: fix
+    components: [es]
+    text: "Relaxed restrictions on snapshot restoration during index checks."
+  - type: fix
+    components: [es]
+    text: "Resolved issue with Stack Monitoring access when `xpack.security.enabled: true` is configured."

--- a/changelog/1.63.0.yaml
+++ b/changelog/1.63.0.yaml
@@ -1,0 +1,54 @@
+version: "1.63.0"
+release_date: "2025-03-12"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-26791](https://www.cve.org/CVERecord?id=CVE-2025-26791), [CWE-772](https://cwe.mitre.org/data/definitions/772.html)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-57699](https://nvd.nist.gov/vuln/detail/CVE-2024-53990) [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) [CVE-2025-24970](https://nvd.nist.gov/vuln/detail/CVE-2025-24970)"
+  - type: new
+    components: [kbn]
+    text: "9.0.1, 9.0.0, 9.0.0-rc1, 9.0.0-beta1, 8.18.1, 8.18.0, 8.17.6, 8.17.5, 8.17.4, 8.16.6 support"
+  - type: new
+    components: [es]
+    text: "9.0.1, 9.0.0, 9.0.0-rc1, 9.0.0-beta1, 8.18.1, 8.18.0, 8.17.6, 8.17.5, 8.17.4, 8.16.6 support"
+  - type: new
+    components: [es]
+    text: "[Added `groups_not_any_of` and `groups_not_all_of` rules](https://forum.readonlyrest.com/t/support-kbn-ent-managing-forbidden-messages/2623)"
+  - type: new
+    components: [es]
+    text: "[New unified and simplified syntax for groups rules](https://docs.readonlyrest.com/elasticsearch#groups-rules)"
+  - type: enhancement
+    components: [kbn]
+    text: "For Kibana >= 8.14.0: Added backward compatibility to hide the Dashboard app by declaring Analytics|Dashboard and Analytics|Dashboards in the `kibana.hide_apps` rule"
+  - type: enhancement
+    components: [kbn]
+    text: "Added information about skipping patching confirmation prompt to the patching helper"
+  - type: enhancement
+    components: [kbn]
+    text: "[When Kibana is opened in multiple browser tabs, logging into Kibana in one tab automatically logs in all browser tabs]"
+  - type: fix
+    components: [kbn]
+    text: "Don't terminate Kibana when disk reaches low watermark"
+  - type: fix
+    components: [kbn]
+    text: "For Kibana >= 8.15.0: Added support for reporting data stream multitenancy"
+  - type: fix
+    components: [kbn]
+    text: "Silenced \"Error fetching fields for index pattern\" toast messages due to forbidden response in Kibana Dashboard and Discover page"
+  - type: fix
+    components: [kbn]
+    text: "For Kibana >= 8.17.0: Fixed Elasticsearch navigation header being visible when `kibana.hide_apps: [ \"Elasticsearch\" ]`"
+  - type: fix
+    components: [kbn]
+    text: "[For Kibana >= 8.5.0: Fixed Dev tools play buttons not being visible for RO users](https://forum.readonlyrest.com/t/ldap-multitenancy-with-no-group-name-to-index-name-relation/2742/8)"
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with hiding the dashboard app when using regular expressions in the kibana_hide_apps field"
+  - type: fix
+    components: [es]
+    text: "Fixed various issues with restoring snapshot API"
+  - type: fix
+    components: [es]
+    text: "Fixed data streams, index, and component templates being forbidden for RW users in stack management"

--- a/changelog/1.64.0.yaml
+++ b/changelog/1.64.0.yaml
@@ -1,0 +1,48 @@
+version: "1.64.0"
+release_date: "2025-05-11"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-53382](https://nvd.nist.gov/vuln/detail/CVE-2024-53382), [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789), [CVE-2025-29774](https://www.cve.org/CVERecord?id=CVE-2025-29774)"
+  - type: security
+    components: [es]
+    text: "[CVE-2023-3894](https://nvd.nist.gov/vuln/detail/CVE-2023-3894), [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193)"
+  - type: warning
+    components: [es]
+    text: "Acknowledgement needs to be accepted before the Elasticsearch patching process. For scripts, you can [set the flag](https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch) to automate the process."
+  - type: new
+    components: [kbn]
+    text: "Added an endpoint to retrieve all user tenancies via the ReadonlyREST API. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/User's%20tenants/get_api_ror_user_tenants) for usage details."
+  - type: new
+    components: [kbn]
+    text: "Introduced support for passing `x-ror-tenancy-id` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details."
+  - type: new
+    components: [kbn]
+    text: "Introduced support for passing `x-ror-impersonating` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details."
+  - type: enhancement
+    components: [kbn]
+    text: "Retains the currently selected group information after user logout. This setting is user-configurable and disabled by default."
+  - type: enhancement
+    components: [kbn]
+    text: "Displays [detailed \"reason\" messages from the ROR Elasticsearch](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration) response in the login form instead of a generic \"Wrong credentials\" message."
+  - type: enhancement
+    components: [kbn]
+    text: "Added support for passing additional [SAML](https://docs.readonlyrest.com/kibana#additional-parameters) and [OIDC](https://docs.readonlyrest.com/kibana#additional-parameters) config parameters via `kibana.yml`."
+  - type: enhancement
+    components: [kbn]
+    text: "Adjusted ReadonlyREST plugin UI styles for compatibility with Kibana 9.x."
+  - type: enhancement
+    components: [es]
+    text: "Username duplication check in the \"users\" section of ROR ES settings can [be optionally disabled](https://docs.readonlyrest.com/elasticsearch#users_section_duplicate_usernames_detection)."
+  - type: enhancement
+    components: [es]
+    text: "Added support for [`readonlyrest.global_settings`](https://docs.readonlyrest.com/elasticsearch#global-settings) in Elasticsearch ROR settings."
+  - type: fix
+    components: [kbn]
+    text: "Resolved an unhandled error when `logging.root.level` is set to `all` in `kibana.yml`."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with retrieving username and group information in AFDS OIDC."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API request."

--- a/changelog/1.64.1.yaml
+++ b/changelog/1.64.1.yaml
@@ -1,0 +1,6 @@
+version: "1.64.1"
+release_date: "2025-05-13"
+entries:
+  - type: fix
+    components: [es]
+    text: "Correct patching verification in ROR Docker image entrypoint"

--- a/changelog/1.64.2.yaml
+++ b/changelog/1.64.2.yaml
@@ -1,0 +1,12 @@
+version: "1.64.2"
+release_date: "2025-05-17"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support"
+  - type: new
+    components: [es]
+    text: "9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support"
+  - type: fix
+    components: [es]
+    text: "[Fixed an issue with Elasticsearch patching process on Windows operating systems](https://forum.readonlyrest.com/t/ror-1-64-0-for-es9-0-1-windows-setup/2778)"

--- a/changelog/1.65.0.yaml
+++ b/changelog/1.65.0.yaml
@@ -1,0 +1,51 @@
+version: "1.65.0"
+release_date: "2025-07-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-5889](https://nvd.nist.gov/vuln/detail/CVE-2025-5889)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-29857](https://nvd.nist.gov/vuln/detail/cve-2024-29857) (when FIPS SSL is used)"
+  - type: new
+    components: [kbn]
+    text: "Added support for configuring [JSON log format](https://www.elastic.co/docs/troubleshoot/kibana/using-kibana-server-logs) in `kibana.yml`."
+  - type: new
+    components: [es]
+    text: "[Added support for a new output type: `data_stream` in audit logging](https://docs.readonlyrest.com/elasticsearch/audit#configuration)."
+  - type: new
+    components: [es]
+    text: "Included Elasticsearch node name and cluster name in the audit reports."
+  - type: enhancement
+    components: [kbn]
+    text: "Logged detailed messages when the CSRF token has expired."
+  - type: enhancement
+    components: [kbn]
+    text: "[Added `id_token` as a valid option for `userInfoSource`](https://docs.readonlyrest.com/kibana#user-info-source-methods)."
+  - type: enhancement
+    components: [es]
+    text: "Improved handling of JVM properties related to ROR settings."
+  - type: fix
+    components: [kbn]
+    text: "Fixed OIDC logout redirection issue by switching `redirect_uri` to `id_token_hint` and using `post_logout_redirect_uri`."
+  - type: fix
+    components: [kbn]
+    text: "The ReadonlyREST Kibana plugin now accepts custom appender names defined in `kibana.yml`."
+  - type: fix
+    components: [kbn]
+    text: "When \"Remember Group After Logout\" is enabled, groups without access are correctly ignored during login."
+  - type: fix
+    components: [kbn]
+    text: "Fixed issue where the Kibana index template was not applied for Kibana versions ≥ 8.8.0."
+  - type: fix
+    components: [kbn]
+    text: "Resolved a bug with `readonlyrest_kbn.resetKibanaIndexToTemplate: true` for Kibana 7.x."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue where a custom session index name was not respected after Kibana restart."
+  - type: fix
+    components: [es]
+    text: "Fixed an issue preventing snapshots from being restored when no indices were specified."
+  - type: fix
+    components: [es]
+    text: "File ownership and permissions are now preserved during `ror-tools` patch and unpatch operations."

--- a/changelog/1.65.1.yaml
+++ b/changelog/1.65.1.yaml
@@ -1,0 +1,15 @@
+version: "1.65.1"
+release_date: "2025-07-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support"
+  - type: new
+    components: [es]
+    text: "9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support"
+  - type: new
+    components: [eck]
+    text: "3.1.0 support"
+  - type: fix
+    components: [es]
+    text: "Docker images now start correctly when `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING` is set."

--- a/changelog/1.66.0.yaml
+++ b/changelog/1.66.0.yaml
@@ -1,0 +1,42 @@
+version: "1.66.0"
+release_date: "2025-08-28"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-7339](https://nvd.nist.gov/vuln/detail/CVE-2025-7339), [CVE-2025-7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783), [CVE-2025-54419](https://nvd.nist.gov/vuln/detail/CVE-2025-54419), [CVE-2025-9288](https://nvd.nist.gov/vuln/detail/CVE-2025-9288)"
+  - type: security
+    components: [kbn]
+    text: "[Prevented visibility of hidden functions through Kibana UI search](https://forum.readonlyrest.com/t/hidden-functions-are-available-through-the-search/2840/2)"
+  - type: security
+    components: [es]
+    text: "Removed internal failure details from error responses to prevent unintended information disclosure"
+  - type: new
+    components: [kbn]
+    text: "9.1.3, 9.1.2, 9.0.6, 8.19.3, 8.18.6 support"
+  - type: new
+    components: [es]
+    text: "9.1.3, 9.1.2, 9.0.6, 8.19.3, 8.18.6 support"
+  - type: enhancement
+    components: [es]
+    text: "Refined user metadata selection logic during login to prioritize matched blocks associated with a defined Kibana index"
+  - type: enhancement
+    components: [es]
+    text: "Patching: improved handling of the consent flag when provided via environment variables for more reliable configuration"
+  - type: fix
+    components: [kbn]
+    text: "Resolved issue with index deletion in **Index Management** via Kibana UI"
+  - type: fix
+    components: [kbn]
+    text: "Corrected document display in **Discover** when indices are defined in the user ACL block"
+  - type: fix
+    components: [kbn]
+    text: "Fixed an error preventing **Spaces** from being deleted in Kibana **9.1.0**"
+  - type: fix
+    components: [kbn]
+    text: "Corrected handling of `readonlyrest_kbn.whitelistedPaths` in `kibana.yml` when `xpack.security.enabled: true`"
+  - type: fix
+    components: [kbn]
+    text: "Resolved startup issues for Kibana versions **7.9.0 → 7.10.2**"
+  - type: fix
+    components: [kbn]
+    text: "Fixed report generation when `xpack.security.enabled: true` and `xpack.encryptedSavedObjects.encryptionKey` is set in Kibana **8.19.x** and **9.1.x**"

--- a/changelog/1.66.1.yaml
+++ b/changelog/1.66.1.yaml
@@ -1,0 +1,12 @@
+version: "1.66.1"
+release_date: "2025-09-03"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.1.5, 9.1.4, 9.0.8, 9.0.7 8.19.5, 8.19.4, 8.18.7 support"
+  - type: new
+    components: [es]
+    text: "9.1.5, 9.1.4, 9.0.8, 9.0.7, 8.19.5, 8.19.4, 8.18.8, 8.18.7 support"
+  - type: fix
+    components: [es]
+    text: "[Patching issue in Elasticsearch 9.x, 8.19.x, and 8.18.x that caused startup failures on Java 17](https://forum.readonlyrest.com/t/ror-1-65-1-java-17/2841)"

--- a/changelog/1.67.0.yaml
+++ b/changelog/1.67.0.yaml
@@ -1,0 +1,48 @@
+version: "1.67.0"
+release_date: "2025-10-14"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)"
+  - type: security
+    components: [es]
+    text: "[CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057), [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)"
+  - type: new
+    components: [es]
+    text: "[Added support for defining a custom audit serializer directly in ROR settings (no code required)](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)"
+  - type: new
+    components: [es]
+    text: "[Introduced new predefined audit serializers: `ReportingAllEventsAuditLogSerializer`, `ReportingAllEventsWithQueryAuditLogSerializer`](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers)"
+  - type: new
+    components: [es]
+    text: "Added new rules: [`ror_kbn_authentication`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authentication) and [`ror_kbn_authorization`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authorization), as alternatives to the existing `ror_kbn_auth` rule"
+  - type: enhancement
+    components: [kbn]
+    text: "[Added OIDC `clock-skew-tolerance` configuration option in `kibana.yml`](https://docs.readonlyrest.com/kibana#clock-skew-tolerance)"
+  - type: enhancement
+    components: [kbn]
+    text: "[Added option to disable Kibana termination on watermark errors in `kibana.yml`](https://docs.readonlyrest.com/kibana#terminate-kibana-on-es-high-watermark)"
+  - type: fix
+    components: [kbn]
+    text: "Logout did not invalidate the app session when the `ror_kbn_auth` rule was used with local group definitions"
+  - type: fix
+    components: [kbn]
+    text: "[Restored keyword field value suggestions in Discover/Data View filters](https://forum.readonlyrest.com/t/kibana-data-view-filter-not-working-with-keyword/2843)"
+  - type: fix
+    components: [kbn]
+    text: "Integration-based options were visible in search results even when the app was marked as hidden"
+  - type: fix
+    components: [kbn]
+    text: "Index Management appeared in app search results even when the app was declared as hidden"
+  - type: fix
+    components: [kbn]
+    text: "Resolved an issue with CSRF token override when multiple browser tabs were open"
+  - type: fix
+    components: [kbn]
+    text: "Fixed OIDC compatibility for Kibana 7.10.2 and earlier"
+  - type: fix
+    components: [es]
+    text: "Restored backward compatibility for custom audit log serializer implementations extending the `DefaultAuditLogSerializer` class. Custom serializers compiled against ROR 1.65 or 1.66 that use `DefaultAuditLogSerializer` must be recompiled to work correctly"
+  - type: fix
+    components: [es]
+    text: "Fixed a defect that broke the \"Snapshot and Restore\" functionality in Kibana"

--- a/changelog/1.67.1.yaml
+++ b/changelog/1.67.1.yaml
@@ -1,0 +1,30 @@
+version: "1.67.1"
+release_date: "2025-11-03"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.0, 9.1.6, 8.19.6 support"
+  - type: new
+    components: [es]
+    text: "9.2.0, 9.1.6, 8.19.6 support"
+  - type: enhancement
+    components: [es]
+    text: "Allow using the `actions` rule with the `kibana` rule in the same block when `kibana.access: unrestricted`"
+  - type: fix
+    components: [kbn]
+    text: "Fixed JWT handling for wrong license edition"
+  - type: fix
+    components: [kbn]
+    text: "Suppressed “Forbidden” toast in Discover/Dashboard on Kibana 8.x–9.x"
+  - type: fix
+    components: [kbn]
+    text: "[Resolved report download failure on Kibana 9.1.x](https://forum.readonlyrest.com/t/unable-to-download-reports-from-kibana/2859/2)"
+  - type: fix
+    components: [kbn]
+    text: "Fixed timeout when saving Security settings"
+  - type: fix
+    components: [kbn]
+    text: "Restored visibility of reports when multiple data streams exist for a reporting index"
+  - type: fix
+    components: [kbn]
+    text: "Fixed invisible reports for non-tenancy users on Kibana 9.1.x"

--- a/changelog/1.67.2.yaml
+++ b/changelog/1.67.2.yaml
@@ -1,0 +1,15 @@
+version: "1.67.2"
+release_date: "2025-11-13"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.1, 9.1.7, 8.19.7 support"
+  - type: new
+    components: [es]
+    text: "9.2.1, 9.1.7, 8.19.7 support"
+  - type: fix
+    components: [kbn]
+    text: "Fixed SAML/OIDC provider support behind a reverse proxy when `server.rewriteBasePath: false` is set in kibana.yml"
+  - type: fix
+    components: [es]
+    text: "Delegated handling of certain internal exceptions to Elasticsearch, preserving native error responses"

--- a/changelog/1.67.3.yaml
+++ b/changelog/1.67.3.yaml
@@ -1,0 +1,12 @@
+version: "1.67.3"
+release_date: "2025-11-29"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support"
+  - type: new
+    components: [es]
+    text: "9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support"
+  - type: fix
+    components: [es]
+    text: "Resolved index resolution compatibility issue with Elasticsearch 9.1.7"

--- a/changelog/1.68.0.yaml
+++ b/changelog/1.68.0.yaml
@@ -1,0 +1,60 @@
+version: "1.68.0"
+release_date: "2026-01-07"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-51999](https://nvd.nist.gov/vuln/detail/CVE-2024-51999), [CVE-2025-65945](https://nvd.nist.gov/vuln/detail/CVE-2025-65945)"
+  - type: security
+    components: [es]
+    text: "[CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735), [CVE-2025-66453](https://nvd.nist.gov/vuln/detail/CVE-2025-66453)"
+  - type: warning
+    components: [es]
+    text: "Audit outputs now use the round-robin strategy for custom audit clusters. [Audit nodes must belong to the same Elasticsearch cluster; otherwise, audit events may be incomplete](https://docs.readonlyrest.com/elasticsearch/audit#custom-audit-cluster)  for configuration guidelines."
+  - type: new
+    components: [kbn]
+    text: "9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support"
+  - type: new
+    components: [es]
+    text: "9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support"
+  - type: new
+    components: [kbn]
+    text: "Added \"Remember last picked tenant\" feature for external identity providers"
+  - type: new
+    components: [kbn]
+    text: "Introduced support for the Kibana Data Set Quality beta application"
+  - type: new
+    components: [kbn]
+    text: "Restyled ROR menu featuring searchable tenancy selector"
+  - type: new
+    components: [es]
+    text: "Added new rules: [`jwt_authentication`](https://docs.readonlyrest.com/elasticsearch#jwt_authentication) and [`jwt_authorization`](https://docs.readonlyrest.com/elasticsearch#jwt_authorization), as alternatives to the existing `jwt_auth` rule"
+  - type: new
+    components: [es]
+    text: "[New audit log serializer compliant with Elastic Common Schema (ECS)](https://docs.readonlyrest.com/elasticsearch/audit#using-ecs-serializer)"
+  - type: new
+    components: [es]
+    text: "[The audit can be enabled or disabled on the block level](https://docs.readonlyrest.com/elasticsearch/audit#configuration)"
+  - type: enhancement
+    components: [kbn]
+    text: "Disabled caching in the Login CSRF protection mechanism."
+  - type: enhancement
+    components: [kbn]
+    text: "Made the tenant indicator always visible and improved its dropdown behavior"
+  - type: enhancement
+    components: [kbn]
+    text: "Added stack traces to ReadonlyREST KBN plugin error logs for easier debugging"
+  - type: enhancement
+    components: [es]
+    text: "[Added LDAP connection health checking to prevent stale connection authentication failures](https://forum.readonlyrest.com/t/ldap-connection-timeout-leads-to-authentication-error/2899)"
+  - type: enhancement
+    components: [es]
+    text: "[Enable nested field definitions in the configurable audit log serializer for more flexible audit logging](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)"
+  - type: enhancement
+    components: [es]
+    text: "[The predefined audit log serializers](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers) now include a new `logged_user` field, which contains a human-readable username"
+  - type: fix
+    components: [kbn]
+    text: "Resolved an issue causing the Kibana Search Sessions app to fail on Kibana 8.x"
+  - type: fix
+    components: [es]
+    text: "[Fixed cluster resolution issues that caused Kibana errors and unexpected logouts in versions 8.19.x and above](https://forum.readonlyrest.com/t/errors-after-upgrade-kibana-7-17-29-to-8-19-7/2887)"

--- a/changelog/1.69.0.yaml
+++ b/changelog/1.69.0.yaml
@@ -1,0 +1,78 @@
+version: "1.69.0"
+release_date: "2026-04-02"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), [CVE-2025-69873](https://nvd.nist.gov/vuln/detail/CVE-2025-69873), [CVE-2026-2391](https://nvd.nist.gov/vuln/detail/CVE-2026-2391), [CVE-2026-25639](https://nvd.nist.gov/vuln/detail/CVE-2026-25639), [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904), [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449), [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599), [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750), [CVE-2026-4867](https://nvd.nist.gov/vuln/detail/CVE-2026-4867), [CVE-2026-34601](https://www.tenable.com/cve/CVE-2026-34601), [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/cve-2022-31129)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[Added Fleet support via native API key and service account token authentication (ES 7.14+)](https://docs.readonlyrest.com/elasticsearch/fleet)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard available in the Kibana plugin now supports audit events written to data streams"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard provided by the Kibana plugin can now be used with the ECS (Elastic Common Schema) audit index"
+  - type: new
+    components: [kbn]
+    text: "[Added support for opening different tenancies in separate tabs](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "[Added support for sharing links to Kibana visualizations for the selected tenancy](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "Added support for rolling upgrades when upgrading the ROR Elasticsearch plugin and ROR Kibana plugin in a cluster"
+  - type: enhancement
+    components: [kbn]
+    text: "Removed the need for manual username input in the impersonation mechanism"
+  - type: enhancement
+    components: [kbn]
+    text: "Fixed an error in Kibana caused by empty data streams in Kibana 8.18.0+"
+  - type: enhancement
+    components: [kbn]
+    text: "Added a fallback for an empty `indices` field in the Audit Dashboard"
+  - type: enhancement
+    components: [kbn]
+    text: "[Updated custom metadata examples to use the new method. `getIdentitySession` and `getAuthorizationHeaders` are now deprecated in favor of `getUserRequestIdentity`, `getIdentitySessionHeaders`, and `getWhitelistedHeaders`](https://docs.readonlyrest.com/develop/examples/custom-middleware)"
+  - type: enhancement
+    components: [es]
+    text: "[`token_authentication` rule extended with `api_key` and `service_token` types](https://docs.readonlyrest.com/elasticsearch#token_authentication)"
+  - type: enhancement
+    components: [es]
+    text: "[Audit log entries and ACL history now include a human-readable reason when a request is denied, making access-control troubleshooting significantly easier](https://forum.readonlyrest.com/t/distinguish-between-wrong-credentials-and-missing-permissions/2914)"
+  - type: enhancement
+    components: [es]
+    text: "Added the new `matched_block_names` field to audit entries created by audit log serializers other than ECS and custom serializers. The `reason` field is now deprecated."
+  - type: enhancement
+    components: [es]
+    text: "Users defined with LDAP, external, and `ror_kbn` authentication are no longer treated as local users by the impersonation mechanism"
+  - type: enhancement
+    components: [es]
+    text: "The ROR Kibana plugin can no longer be used when the `prompt_for_basic_auth: true` setting is configured"
+  - type: fix
+    components: [kbn]
+    text: "Resolved a memory leak related to direct calls via the Kibana API"
+  - type: fix
+    components: [kbn]
+    text: "No longer shows the \"Data Set Quality\" and \"Index management\" applications to users with RO or RO_strict access"
+  - type: fix
+    components: [kbn]
+    text: "Fixed JWT token authorization when using embedded Kibana"
+  - type: fix
+    components: [kbn]
+    text: "Fixed the styling of the page-not-found screen for Kibana 9.x"
+  - type: fix
+    components: [kbn]
+    text: "Correctly displays the \"Who uses what indices?\" Audit Dashboard visualization when indices are not specified in the audit events"
+  - type: fix
+    components: [es]
+    text: "[Improved stability when sending audit logs to another cluster, so temporary remote cluster outages no longer affect the main cluster](https://forum.readonlyrest.com/t/sending-logs-to-another-cluster/2925)"
+  - type: fix
+    components: [es]
+    text: "Fixed Search Profiler being inactive in Kibana 8.18.0+"
+  - type: fix
+    components: [es]
+    text: "`beshultd/elasticsearch-readonlyrest` images for ES 7.16.x, 7.17.0–7.17.6, and 8.0.x–8.4.x now ship with a patched JDK, replacing bundled JDK 17.0.0–17.0.4 / JDK 18, which crashes on cgroup v2 hosts due to JDK-8287073"

--- a/changelog/1.69.1.yaml
+++ b/changelog/1.69.1.yaml
@@ -1,0 +1,30 @@
+version: "1.69.1"
+release_date: "2026-04-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)"
+  - type: new
+    components: [kbn]
+    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+  - type: new
+    components: [es]
+    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+  - type: new
+    components: [eck]
+    text: "3.4.0 support"
+  - type: fix
+    components: [kbn]
+    text: "Fixed `jsonwebtoken-ancient` being stripped from Kibana builds earlier than 7.11.0"
+  - type: fix
+    components: [kbn]
+    text: "Filtered out Fleet-based apps from search results when Management is hidden in Kibana 8.x and 9.x"
+  - type: fix
+    components: [kbn]
+    text: "Fixed `/pkp/session-probe` requests being blocked by browsers that enforce async-only calls"
+  - type: fix
+    components: [kbn]
+    text: "Fixed a problem with redirecting to the login form after a 401 error following a session probe check"
+  - type: fix
+    components: [es]
+    text: "Fixed a missing Kibana access policy in the metadata response when the matched ACL block has no `kibana` section configured"


### PR DESCRIPTION
## Why

Phase 2 of the UI-for-Changelog rollout (tracker: [`beshu-tech/ror-api#86`](https://github.com/beshu-tech/ror-api/issues/86)).

Turns the free-text `changelog.md` into per-version YAML files. Each release lives in its own file at `changelog/{version}.yaml`. After Phase 3, `changelog.md` is auto-generated from these YAMLs — humans never touch it directly.

## Generated by

`scripts/migrate_changelog.py` in `beshu-tech/ror-api` ([PR #90](https://github.com/beshu-tech/ror-api/pull/90)). One-shot. Reuses ror-api's existing parsers (`is_version_line`, `parse_version_details`, `HashTitles.from_md`) to guarantee parsing behavior matches production.

## Results

| Metric | Value |
|---|---|
| Versions | 66 |
| Entries | 518 |
| **Hash parity vs original** | **66/66 ✓** |
| Edge cases (manual review) | 3 |

## Hash parity — why it matters

`ror-api` stores LLM-generated detailed descriptions per entry, keyed by `HashTitles.from_md(entry_bullets)`. If the YAML→MD render produces different bullets than the original, the hash changes → ror-api re-runs the LLM for every "changed" entry → cost + delay + churn.

**This PR is hash-stable.** Every existing LLM description survives.

The script discovered `(KBN/ES)`, `(KBN|ES)`, `(ES & KBN)` mixed-separator entries that would not survive canonical render. Fix: optional `components_raw` field on entries — preserves the original separator/order verbatim while keeping a normalized `components: [es, kbn]` array for downstream consumers. Pure form-driven future entries omit `components_raw`.

## Edge cases (3 entries) — preserved verbatim, flagged inline

Each YAML for these versions has a `# EDGE CASE — manual review needed` comment block with the original bullet. Same `components_raw` mechanism keeps hashes stable; you can leave as-is or normalize manually.

| Version | Component string | Bullet |
|---|---|---|
| `1.43.0` | `KBN\|PRO` | Fix: ROR menu title wraps when version text is too short (cosmetic) |
| `1.48.0` | `KBN < 7.9.x` | Fix: using a custom kibana index in cooperation with ROR Free |
| `1.49.0` | `KBN < 7.9.0` | Fix: logging issue when two Kibanas are handled by one browser at the same time |

## Sample (1.69.0.yaml)

```yaml
version: "1.69.0"
release_date: "2026-04-02"
entries:
  - type: security
    components: [kbn]
    text: "[CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), ..."
  - type: new
    components: [es, kbn]
    components_raw: "KBN/ES"      # preserved verbatim (hash parity)
    text: "[Added Fleet support via native API key and service account token authentication (ES 7.14+)](...)"
  - type: new
    components: [kbn]              # clean entry, no components_raw needed
    text: "[Added support for opening different tenancies in separate tabs](...)"
```

## What this PR does NOT do

- Does not delete `changelog.md` — stays as-is until Phase 3 cuts over (render workflow regens it from YAMLs)
- Does not add Issue Forms / form action / maintainer gate — Phase 3 work
- Does not modify `changelog_watch.yml` — Phase 3 swaps the payload to structured

## After merge

Branch `migrate/yaml-changelog` lands on `master`. Phase 3 adds the workflow files + Issue Forms in a separate PR, coordinated with ror-api webhook contract changes.

## Demo

Schema + render verified end-to-end on [`ton77v/changelog-forms-demo`](https://github.com/ton77v/changelog-forms-demo). Same YAML format, same parser, same render logic that Phase 3 will deploy here.

> <signature>🦀 **sent by Claude Code**</signature>