### PR TITLE
feat(changelog): Phase 3 - Issue Forms + render + structured webhook

### DIFF
--- a/.github/ISSUE_TEMPLATE/changelog-entry.yml
+++ b/.github/ISSUE_TEMPLATE/changelog-entry.yml
@@ -1,0 +1,39 @@
+name: Changelog (maintainers only)
+description: Add changelog entries (one or many) — restricted to repo maintainers
+title: "[Changelog] (auto-renamed on submit)"
+labels: ["changelog-entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **🔒 Maintainers only.** Non-maintainer issues are auto-closed within ~30s by the [maintainer gate workflow](../blob/main/.github/workflows/maintainer_gate.yml). If you're not a maintainer, please use [Discussions](../../discussions) or contact the team directly.
+
+        Paste one line per entry — single or whole release, same form.
+
+        **Format:** `<type> (<component>) <text>` — same as `changelog.md` today
+
+        - **types:** `new`, `fix`, `security`, `warning`, `enhancement`
+        - **components:** `es`, `kbn`, `eck` — combinable: `es|kbn`, `kbn|eck`, `es|kbn|eck`
+        - text supports markdown links
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: "1.68.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      placeholder: |
+        new (es) 9.0.2, 8.18.2, 8.17.7 support
+        new (kbn) 9.0.2, 8.18.2, 8.17.7 support
+        fix (eck) Operator handling of TLS rotation
+        fix (es|kbn) tenancy selector with jwt_auth
+        security (es) CVE-2024-53382
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Source / discussion
+    url: https://github.com/beshu-tech/ror-api/issues/86
+    about: This is a demo for ror-api#86 — UI for Changelog

--- a/.github/changelog-config.yml
+++ b/.github/changelog-config.yml
@@ -1,0 +1,12 @@
+# Changelog form behavior.
+# Single source of truth — change via PR, never via repo UI.
+# Consumed by .github/workflows/changelog_form.yml.
+
+# When true: form-opened PRs are auto-merged once required status checks pass
+# (or immediately if no branch protection). When false: maintainer reviews + clicks merge.
+#
+# In prod, recommended rollout:
+#   1. Ship with auto_merge: false — team learns the loop by reviewing each PR manually
+#   2. Once trusted, flip to true via PR + add branch protection requiring `validate-and-render`
+#   3. For the gate to actually block on CI: bot needs a PAT (GITHUB_TOKEN-authored PRs skip CI)
+auto_merge: true

--- a/.github/changelog-config.yml
+++ b/.github/changelog-config.yml
@@ -9,4 +9,4 @@
 #   1. Ship with auto_merge: false — team learns the loop by reviewing each PR manually
 #   2. Once trusted, flip to true via PR + add branch protection requiring `validate-and-render`
 #   3. For the gate to actually block on CI: bot needs a PAT (GITHUB_TOKEN-authored PRs skip CI)
-auto_merge: true
+auto_merge: false

--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Changelog version",
+  "type": "object",
+  "required": ["version", "release_date", "entries"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-(rc|beta|alpha)\\d*)?$",
+      "description": "Semver; pre-release suffixes -rcN/-betaN/-alphaN allowed"
+    },
+    "release_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "components", "text"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": ["new", "fix", "security", "warning", "enhancement"]
+          },
+          "components": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "enum": ["es", "kbn", "eck"] }
+          },
+          "components_raw": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional. Preserves original separator/order (e.g. 'KBN/ES', 'ES & KBN') for hash parity with ror-api's stored LLM descriptions. Only present on migrated historical entries; new form-driven entries omit it."
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -15,32 +15,37 @@
       "format": "date"
     },
     "entries": {
-      "type": "array",
-      "minItems": 1,
+      "type": ["array", "null"],
       "items": {
         "type": "object",
-        "required": ["type", "components", "text"],
+        "required": ["type", "text"],
         "additionalProperties": false,
         "properties": {
           "type": {
-            "enum": ["new", "fix", "security", "warning", "enhancement"]
+            "type": ["string", "null"],
+            "description": "Canonical (new/fix/security/warning/enhancement) or arbitrary string for legacy entries that don't match a canonical type."
           },
           "components": {
             "type": "array",
             "minItems": 1,
             "uniqueItems": true,
-            "items": { "enum": ["es", "kbn", "eck"] }
+            "items": { "enum": ["es", "kbn", "eck"] },
+            "description": "Canonical component(s). Required for new form-driven entries."
           },
           "components_raw": {
             "type": "string",
             "minLength": 1,
-            "description": "Optional. Preserves original separator/order (e.g. 'KBN/ES', 'ES & KBN') for hash parity with ror-api's stored LLM descriptions. Only present on migrated historical entries; new form-driven entries omit it."
+            "description": "Preserves original separator/order (e.g. 'KBN/ES', 'KBN ENT/PRO') for hash parity with ror-api stored LLM descriptions. Required when `components` is absent — used for legacy migration entries that don't map cleanly to canonical components."
           },
           "text": {
             "type": "string",
             "minLength": 1
           }
-        }
+        },
+        "anyOf": [
+          { "required": ["components"] },
+          { "required": ["components_raw"] }
+        ]
       }
     }
   }

--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -15,7 +15,8 @@
       "format": "date"
     },
     "entries": {
-      "type": ["array", "null"],
+      "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": ["type", "text"],

--- a/.github/workflows/changelog_form.yml
+++ b/.github/workflows/changelog_form.yml
@@ -1,0 +1,249 @@
+name: Changelog form
+
+# Parses Issue Form body. On success: writes changelog/{version}.yaml and opens
+# (or refreshes) a PR via peter-evans/create-pull-request. On error: posts
+# updateable bot comment with parse errors. Title is auto-renamed once parsed.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  parse:
+    if: contains(github.event.issue.labels.*.name, 'changelog-entry')
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.parse.outputs.ok }}
+      version: ${{ steps.parse.outputs.version }}
+      yaml_path: ${{ steps.parse.outputs.yaml_path }}
+      pr_title: ${{ steps.parse.outputs.pr_title }}
+      commit_msg: ${{ steps.parse.outputs.commit_msg }}
+      branch: ${{ steps.parse.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse form, write YAML or post errors
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+            const body = context.payload.issue.body || ''
+            const marker = '<!-- changelog-form-bot -->'
+
+            // Issue Forms render: ### <Field>\n\n<value>\n\n### <Next>...
+            const sections = {}
+            let cur = null, buf = []
+            for (const line of body.split(/\r?\n/)) {
+              if (line.startsWith('### ')) {
+                if (cur) sections[cur] = buf.join('\n').trim()
+                cur = line.slice(4).trim()
+                buf = []
+              } else {
+                buf.push(line)
+              }
+            }
+            if (cur) sections[cur] = buf.join('\n').trim()
+
+            const version = (sections['Version'] || '').trim()
+            const stripFence = (s) => {
+              const lines = s.split(/\r?\n/)
+              if (lines[0] && /^```/.test(lines[0].trim())) lines.shift()
+              if (lines.length && /^```/.test((lines[lines.length - 1] || '').trim())) lines.pop()
+              return lines.join('\n')
+            }
+            const notes = stripFence((sections['Notes'] || '').trim()).trim()
+
+            const errors = []
+            if (!/^\d+\.\d+\.\d+(-(rc|beta|alpha)\d*)?$/.test(version)) {
+              errors.push(`Version must match X.Y.Z (optionally -rcN/-betaN/-alphaN) — got: \`${version}\``)
+            }
+            if (!notes) errors.push('Notes is empty')
+
+            const TYPE_MAP = {
+              new: 'new', feat: 'new', feature: 'new',
+              fix: 'fix', bugfix: 'fix',
+              security: 'security', 'security fix': 'security', sec: 'security',
+              warning: 'warning', warn: 'warning',
+              enhancement: 'enhancement', enh: 'enhancement', improve: 'enhancement',
+            }
+            // Components: es, kbn, eck — combinable via any of `|`, `/`, `&`, `,`, ` and `.
+            // Real changelog.md uses mixed separators (`KBN/ES`, `ES & KBN`, etc); we normalize.
+            // Canonical output order: es, kbn, eck (matches dominant pattern in existing changelog.md).
+            // Edge cases (~0.7%: `KBN-PRO`, `KBN < 7.9.x`) are rejected here → user edits YAML directly.
+            const COMP_ORDER = ['es', 'kbn', 'eck']
+            const parseComps = (raw) => {
+              const normalized = raw.toLowerCase().replace(/\s+and\s+/g, '|').replace(/[\/&,]/g, '|')
+              const parts = normalized.replace(/\s+/g, '').split('|').filter(Boolean)
+              if (!parts.length) return null
+              const unknown = parts.filter(p => !COMP_ORDER.includes(p))
+              if (unknown.length) return null
+              return COMP_ORDER.filter(c => parts.includes(c))
+            }
+
+            const entries = []
+            const lineRe = /^\s*(?<type>[\w ]+?)\s*\(\s*(?<comp>[^)]+?)\s*\)\s*:?\s*(?<text>.+?)\s*$/i
+
+            notes.split(/\r?\n/).forEach((raw, i) => {
+              const line = raw.trim()
+              if (!line || line.startsWith('#') || line.startsWith('//')) return
+              const m = line.match(lineRe)
+              if (!m) {
+                errors.push(`Line ${i + 1}: cannot parse \`${line}\` — expected \`<type> (<component>) <text>\``)
+                return
+              }
+              const type = TYPE_MAP[m.groups.type.toLowerCase()]
+              const comp = parseComps(m.groups.comp)
+              if (!type) errors.push(`Line ${i + 1}: unknown type \`${m.groups.type}\` — use one of: new, fix, security, warning, enhancement`)
+              if (!comp) errors.push(`Line ${i + 1}: unknown component \`${m.groups.comp}\` — use one of: es, kbn, eck (combinable with \`|\`, e.g. es|kbn)`)
+              if (type && comp) entries.push({ type, components: comp, text: m.groups.text })
+            })
+
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+            const findExisting = async () => {
+              const { data: comments } = await github.rest.issues.listComments(ref)
+              return comments.find(c => c.body && c.body.includes(marker))
+            }
+            const upsertComment = async (commentBody) => {
+              const existing = await findExisting()
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: ref.owner, repo: ref.repo, comment_id: existing.id, body: commentBody,
+                })
+              } else {
+                await github.rest.issues.createComment({ ...ref, body: commentBody })
+              }
+            }
+
+            if (errors.length) {
+              const errMsg = `${marker}\n**Could not parse** (${errors.length} issue${errors.length > 1 ? 's' : ''}):\n\n` +
+                errors.map(e => `- ${e}`).join('\n') +
+                `\n\n_Edit the issue body to fix — this comment will refresh._`
+              await upsertComment(errMsg)
+              core.setOutput('ok', 'false')
+              return
+            }
+
+            // Today is intentional — release date defaults to filing day; editable in PR.
+            // Dates and versions are ALWAYS quoted: js-yaml parses unquoted dates as Date
+            // objects, breaking ajv's `type: string` check.
+            const today = new Date().toISOString().slice(0, 10)
+            const yamlEsc = (s) => /[:#\[\]{}&*!|>'"%@`]|^\s|\s$/.test(s) ? JSON.stringify(s) : s
+            let yaml = `version: "${version}"\nrelease_date: "${today}"\nentries:\n`
+            for (const e of entries) {
+              yaml += `  - type: ${e.type}\n`
+              yaml += `    components: [${e.components.join(', ')}]\n`
+              yaml += `    text: ${yamlEsc(e.text)}\n`
+            }
+
+            const yamlPath = `changelog/${version}.yaml`
+            fs.mkdirSync(path.dirname(yamlPath), { recursive: true })
+            fs.writeFileSync(yamlPath, yaml)
+
+            const summary = entries.length === 1
+              ? `${entries[0].type} (${entries[0].components.join('|')}): ${entries[0].text}`.slice(0, 80)
+              : `${entries.length} entries`
+            const prTitle = `[Changelog ${version}] ${summary}`
+
+            if (context.payload.issue.title !== prTitle) {
+              await github.rest.issues.update({ ...ref, title: prTitle })
+            }
+
+            core.setOutput('ok', 'true')
+            core.setOutput('version', version)
+            core.setOutput('yaml_path', yamlPath)
+            core.setOutput('pr_title', prTitle)
+            core.setOutput('commit_msg', `Add changelog entry for ${version} (#${context.issue.number})`)
+            core.setOutput('branch', `changelog/v${version}-issue-${context.issue.number}`)
+
+      - name: Create or update PR
+        if: steps.parse.outputs.ok == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.parse.outputs.branch }}
+          base: master
+          title: ${{ steps.parse.outputs.pr_title }}
+          commit-message: ${{ steps.parse.outputs.commit_msg }}
+          body: |
+            Auto-opened from issue #${{ github.event.issue.number }}.
+
+            Render workflow will regenerate `changelog.md` on merge to `master`.
+
+            ---
+            _Edit the YAML directly in this PR to fix typos or update the release date._
+          delete-branch: true
+          add-paths: |
+            changelog/*.yaml
+
+      # Read changelog-form config (committed to repo at .github/changelog-config.yml).
+      # Adjusting auto_merge etc. = open a PR against the config file, not a UI flip.
+      - name: Read config
+        id: cfg
+        run: |
+          if [ -f .github/changelog-config.yml ]; then
+            echo "auto_merge=$(yq -r '.auto_merge // false' .github/changelog-config.yml)" >> "$GITHUB_OUTPUT"
+          else
+            echo "auto_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auto-merge toggle. Enable by setting `auto_merge: true` in .github/changelog-config.yml.
+      # With `--auto`, GitHub waits for required status checks (branch protection) before merging;
+      # if no checks required, merges immediately.
+      # CAVEAT: bot-authored PRs from GITHUB_TOKEN don't trigger CI (recursion guard).
+      # For a true "wait for green CI" gate in prod: use a PAT in the create-pr step above,
+      # AND set branch protection with validate-and-render required.
+      - name: Enable auto-merge
+        if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url && steps.cfg.outputs.auto_merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+
+      - name: Comment PR link on issue and close
+        if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url
+        uses: actions/github-script@v7
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_OP: ${{ steps.cpr.outputs.pull-request-operation }}
+          AUTOMERGE: ${{ steps.cfg.outputs.auto_merge }}
+        with:
+          script: |
+            const marker = '<!-- changelog-form-bot -->'
+            const op = process.env.PR_OP
+            const url = process.env.PR_URL
+            const automerge = process.env.AUTOMERGE === 'true'
+            const verb = op === 'created' ? 'Opened' : 'Updated'
+            const automergeNote = automerge
+              ? '\n\n_Auto-merge enabled (`.github/changelog-config.yml`) — will merge once required checks pass._'
+              : '\n\n_Edit the YAML directly in the PR for fixes. Merge will trigger `changelog.md` regen._'
+            const body = `${marker}\n${verb} ${url}${automergeNote}`
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+
+            const { data: comments } = await github.rest.issues.listComments(ref)
+            const existing = comments.find(c => c.body && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: ref.owner, repo: ref.repo, comment_id: existing.id, body,
+              })
+            } else {
+              await github.rest.issues.createComment({ ...ref, body })
+            }
+            if (op === 'created' && context.payload.issue.state === 'open') {
+              await github.rest.issues.update({ ...ref, state: 'closed', state_reason: 'completed' })
+            }

--- a/.github/workflows/changelog_watch.yml
+++ b/.github/workflows/changelog_watch.yml
@@ -1,37 +1,55 @@
 name: Watch Changelog
 
+# Phase 3+: fires on changelog/*.yaml changes (single source of truth).
+# Each changed YAML triggers an event-typed webhook to ror-api.
+# The legacy changelog.md push path is gone — changelog.md is now an auto-generated
+# mirror produced by render_changelog.yml. Bot-pushed regens don't trigger this workflow.
+
 on:
   push:
-    branches:  # may need to parameterize this
+    branches:
       - master
     paths:
-      - changelog.md
+      - "changelog/**.yaml"
 
 jobs:
-  on-changelog-update:
+  notify-ror-api:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need prev commit for diff
 
-      - name: Get changelog diff
-        id: changelog
+      - name: Detect changed YAMLs + send per-version webhooks
+        env:
+          API_KEY: ${{ secrets.DOCS_REPO_API_SECRET }}
+          WEBHOOK_URL: ${{ secrets.CHANGELOG_WEBHOOK_URL }}
         run: |
-          git fetch --deepen=1
-          PREV_COMMIT=$(git rev-parse HEAD~1 || echo "")
-          if [ -z "$PREV_COMMIT" ]; then
-            DIFF=$(cat changelog.md)
-          else
-            DIFF=$(git diff "$PREV_COMMIT" HEAD -- changelog.md)
-          fi
-          
-          echo "DIFF<<EOF" >> $GITHUB_ENV
-          echo "$DIFF" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Send webhook with changelog diff
-        run: |
-          curl --fail --retry 3 -X POST -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.DOCS_REPO_API_SECRET }}" \
-            -d "$(jq -nc --arg diff "$DIFF" '{"changelog_diff": $diff}')" \
-            ${{ secrets.CHANGELOG_WEBHOOK_URL }}
+          set -eo pipefail
+          PREV=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          # Each changed YAML => one event-typed POST. A/M/D classified by git status code.
+          git diff --name-status "$PREV" HEAD -- 'changelog/*.yaml' | while IFS=$'\t' read -r STATUS FILE; do
+            VERSION=$(basename "$FILE" .yaml)
+            case "$STATUS" in
+              A) EVENT="version_added" ;;
+              M) EVENT="version_modified" ;;
+              D) EVENT="version_deleted" ;;
+              *) echo "skip status=$STATUS file=$FILE" && continue ;;
+            esac
+            # Inline YAML content if file exists (skip for deletions)
+            if [ "$EVENT" != "version_deleted" ]; then
+              YAML_CONTENT=$(cat "$FILE")
+              PAYLOAD=$(jq -nc \
+                --arg event "$EVENT" --arg version "$VERSION" --arg yaml "$YAML_CONTENT" \
+                '{event: $event, version: $version, yaml: $yaml}')
+            else
+              PAYLOAD=$(jq -nc \
+                --arg event "$EVENT" --arg version "$VERSION" \
+                '{event: $event, version: $version}')
+            fi
+            echo "POST $EVENT $VERSION"
+            curl --fail --retry 3 -X POST -H "Content-Type: application/json" \
+              -H "x-api-key: $API_KEY" \
+              -d "$PAYLOAD" \
+              "$WEBHOOK_URL"
+          done

--- a/.github/workflows/maintainer_gate.yml
+++ b/.github/workflows/maintainer_gate.yml
@@ -1,0 +1,53 @@
+name: Maintainer gate
+
+# Closes changelog issues filed by non-maintainers. Required ask from review:
+# "restrict TO maintainers ONLY to create these". GitHub has no native persistent
+# setting for this on public repos — action-based gate is the only durable answer.
+# Race: issue is publicly visible ~10-30s before this fires. Accepted tradeoff.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  gate:
+    if: contains(github.event.issue.labels.*.name, 'changelog-entry')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author association
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR']
+            const assoc = context.payload.issue.author_association
+            const ok = allowed.includes(assoc)
+            core.setOutput('ok', ok ? 'true' : 'false')
+            core.setOutput('assoc', assoc)
+            core.info(`author_association=${assoc} ok=${ok}`)
+
+      - name: Reject non-maintainer
+        if: steps.check.outputs.ok != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+            await github.rest.issues.createComment({
+              ...ref,
+              body: [
+                `Thanks for the interest! This issue template is reserved for repo maintainers.`,
+                ``,
+                `If you spotted a bug or have a question, please use [discussions](https://github.com/${context.repo.owner}/${context.repo.repo}/discussions) or contact the team directly.`,
+                ``,
+                `_Auto-closed: \`author_association=${{ steps.check.outputs.assoc }}\`_`,
+              ].join('\n'),
+            })
+            await github.rest.issues.update({ ...ref, state: 'closed', state_reason: 'not_planned' })
+            await github.rest.issues.lock({ ...ref, lock_reason: 'off-topic' })

--- a/.github/workflows/render_changelog.yml
+++ b/.github/workflows/render_changelog.yml
@@ -1,0 +1,115 @@
+name: Render changelog.md
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "changelog/**.yaml"
+      - ".github/workflows/render_changelog.yml"
+      - ".github/schemas/changelog-entry.schema.json"
+  pull_request:
+    paths:
+      - "changelog/**.yaml"
+      - ".github/workflows/render_changelog.yml"
+      - ".github/schemas/changelog-entry.schema.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  validate-and-render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate YAML schema (ajv)
+        run: |
+          npm install --no-save ajv@8 ajv-cli@5 ajv-formats@2
+          for f in changelog/*.yaml; do
+            [ -f "$f" ] || continue
+            npx ajv-cli validate \
+              -s .github/schemas/changelog-entry.schema.json \
+              -d "$f" \
+              -c ajv-formats || exit 1
+          done
+
+      - name: Build releases JSON (with filename)
+        run: |
+          echo '[' > all.json
+          first=true
+          for f in changelog/*.yaml; do
+            [ -f "$f" ] || continue
+            $first || echo ',' >> all.json
+            first=false
+            fname=$(basename "$f" .yaml)
+            yq -o json ". + {\"_filename\": \"$fname\"}" "$f" >> all.json
+          done
+          echo ']' >> all.json
+
+      - name: Validate filename matches inner version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const releases = JSON.parse(fs.readFileSync('all.json', 'utf8'))
+            const mismatches = releases.filter(r => r._filename !== r.version)
+            if (mismatches.length) {
+              for (const r of mismatches) {
+                core.error(`filename ${r._filename}.yaml does not match inner version: ${r.version}`)
+              }
+              core.setFailed(`${mismatches.length} file(s) with filename/version mismatch — rename file or fix version field`)
+            }
+
+      - name: Install semver
+        if: github.event_name == 'push'
+        run: npm install --no-save semver@7
+
+      - name: Render changelog.md
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const semver = require('semver')
+            const releases = JSON.parse(fs.readFileSync('all.json', 'utf8'))
+
+            // Pre-release-aware sort. semver.rcompare handles 1.64.2 > 1.64.2-rc1 etc.
+            releases.sort((a, b) => semver.rcompare(a.version, b.version))
+
+            const TYPE_EMOJI = {
+              new: '🚀New',
+              fix: '🐞Fix',
+              security: '🚨Security Fix',
+              warning: '⚠️Warning',
+              enhancement: '🧐Enhancement',
+            }
+            // `components_raw` (optional) preserves original separator/order for migrated entries
+            // — required for hash parity with ror-api's stored LLM descriptions. New form-driven
+            // entries omit it; renderer falls back to canonical `ES|KBN` join.
+            const compStr = (e) => e.components_raw || e.components.map(c => c.toUpperCase()).join('|')
+
+            let md = '# Changelog\n\n'
+            md += '<!-- AUTO-GENERATED from changelog/*.yaml — do not edit directly -->\n\n'
+            for (const r of releases) {
+              md += `### (${r.release_date}) What's new in **ROR ${r.version}**\n`
+              for (const e of r.entries) {
+                const label = TYPE_EMOJI[e.type] || e.type
+                md += `* **${label}** (${compStr(e)}) ${e.text}\n`
+              }
+              md += '\n'
+            }
+            fs.writeFileSync('changelog.md', md)
+
+      - name: Commit if changed
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add changelog.md
+          if git diff --cached --quiet; then
+            echo "no change"
+          else
+            git commit -m "regen changelog.md from YAMLs"
+            git push
+          fi

--- a/changelog/1.26.0.yaml
+++ b/changelog/1.26.0.yaml
@@ -188,11 +188,11 @@ entries:
     components: [kbn]
     text: "\"x-\" headers should be forwarded in /login route when proxy passthrough is enabled"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** [\\(KBN\\) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "[(KBN) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)"
   - type: fix
     components: [kbn]
     text: "SAML metadata.xml endpoint not responding"
@@ -206,11 +206,11 @@ entries:
     components: [es]
     text: "\\_readonlyrest/metadata/current\\_user should be always allowed by filter/fields rule ### What's new in 1.20.0"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** 7.7.1, 7.8.0 support"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "7.7.1, 7.8.0 support"
   - type: enhancement
     components: [kbn]
     text: "tidy up audit page"
@@ -251,11 +251,11 @@ entries:
     components: [es]
     text: "[tasks leak bug](https://forum.readonlyrest.com/t/lots-of-active-tasks-in-cat-tasks/1593) ### What's new in 1.19.5"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** 7.7.0, 7.6.2, 6.8.9, 6.8.8 support"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "7.7.0, 7.6.2, 6.8.9, 6.8.8 support"
   - type: enhancement
     components: [es, kbn]
     components_raw: "ES/KBN"
@@ -487,11 +487,11 @@ entries:
     components: [es]
     text: "Example projects with custom audit log serializers"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: unknown_type
     # original: "* 🐞**Fix** \\(KBN\\) Prevent index migration after kibana startup"
     type: <unknown>
-    components_raw: ""
-    text: ""
+    components_raw: "KBN"
+    text: "Prevent index migration after kibana startup"
   - type: enhancement
     components: [kbn]
     text: "If default space doesn't exist in kibana index then copy from default one"
@@ -509,17 +509,17 @@ entries:
     components: [kbn]
     text: "Kibana sessions stored in ES index"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: unknown_type
     # original: "* 🐞**Fix** \\(ES\\) issue with in-index settings auto-reloading"
     type: <unknown>
-    components_raw: ""
-    text: ""
+    components_raw: "ES"
+    text: "issue with in-index settings auto-reloading"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: unknown_type
     # original: "* 🐞**Fix** \\(ES\\) \\_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8"
     type: <unknown>
-    components_raw: ""
-    text: ""
+    components_raw: "ES"
+    text: "\\_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8"
   - type: new
     components: [es, kbn]
     components_raw: "ES/KBN"
@@ -710,11 +710,11 @@ entries:
     components_raw: "KBN/ENT"
     text: "temporarily roll back \"support for unlimited tenancies\" ### What's new in 1.18.3"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support added for ES/Kibana 6.8.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support added for ES/Kibana 6.8.1"
   - type: enhancement
     components: [es]
     text: "Crash ES on invalid settings instead of stalling forever"
@@ -758,11 +758,11 @@ entries:
     components: [kbn]
     text: "Avoid sporadic errors on Save/Load buttons ### What's new in 1.18.2"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support for Elasticsearch & Kibana 7.2.0"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch & Kibana 7.2.0"
   - type: fix
     components: [es]
     text: "restore indices (\"IDX\") in audit logging"
@@ -884,11 +884,11 @@ entries:
     components_raw: "Enterprise"
     text: "SAML connector \"buttonName\" didn't work ### What's new in 1.18.0"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support for Elasticsearch & Kibana 7.0.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch & Kibana 7.0.1"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:elasticsearch
     # original: "* **🧐Enhancement** \\(Elasticsearch\\) empty array values in settings are invalid"
@@ -914,11 +914,11 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "History cleaning can now be disabled (\"clearSessionOnEvents\") ### What's new in 1.17.7"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support for Elasticsearch 7.0.0 \\(Kibana is coming soon\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch 7.0.0 (Kibana is coming soon)"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:elasticsearch
     # original: "* **🧐Enhancement** \\(Elasticsearch\\) rewritten LDAP connector"
@@ -944,11 +944,11 @@ entries:
     components_raw: "Enterprise/PRO"
     text: "Fix \"connectorsService\" error in installation ### What's new in 1.17.5"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.7.1"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise,gt;= kibana 6.6.0
     # original: "* **🧐Enhancement** \\(Enterprise &gt;= Kibana 6.6.0\\) Multiple SAML identity provider"
@@ -974,23 +974,23 @@ entries:
     components_raw: "Enterprise"
     text: "Don't reject requests if SAML groups are not configured"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** filter/fields rules not working in msearch \\(in 6.7.x\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "filter/fields rules not working in msearch (in 6.7.x)"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Print whole LDAP search query in debug log ### What's new in 1.17.4"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Print whole LDAP search query in debug log ### What's new in 1.17.4"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.0"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.7.0"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) JWT query param is the preferred credentials provider"
@@ -1010,29 +1010,29 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "ro users can dismiss telemetry form"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Audit logging in 5.1.x now works again"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** unpredictable behaviour of \"filter\" and \"fields\" when using external auth"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "unpredictable behaviour of \"filter\" and \"fields\" when using external auth"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** LDAP ConcurrentModificationException"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "LDAP ConcurrentModificationException"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Audit logging in 5.1.x now works again"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🐞Fix** \\(PRO/Enterprise\\) JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly"
@@ -1070,29 +1070,29 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "barring static files requests caused sudden logout"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Numerous fixes to better support Kibana 6.6.x"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Numerous fixes to better support Kibana 6.6.x"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Critical fixes in new Scala core"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Critical fixes in new Scala core"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Exception in reindex requests caused tenancy templating to fail"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Exception in reindex requests caused tenancy templating to fail"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🐞Fix** \\(PRO/Enterprise\\) SAML now works well in 6.6.x"
@@ -1142,17 +1142,17 @@ entries:
     components_raw: "Elasticsearch"
     text: "New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** Support for Kibana/Elasticsearch 6.6.0, 6.6.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.6.0, 6.6.1"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** Internode SSL \\(ES 6.3.x onwards\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Internode SSL (ES 6.3.x onwards)"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🧐Enhancement**\\(PRO/Enterprise\\) UI appearence"
@@ -1160,35 +1160,35 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "UI appearence"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Made HTTP Connection configurable \\(PR \\#410\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Made HTTP Connection configurable (PR \\#410)"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** slow boot due to SecureRandom waiting for sufficient entropy"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "slow boot due to SecureRandom waiting for sufficient entropy"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix** Enable kibana\\_access:ro to create short urls in es6.3+ \\(PR \\#408\\) ### What's new in 1.16.34"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Enable kibana\\_access:ro to create short urls in es6.3+ (PR \\#408) ### What's new in 1.16.34"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** X-Forwarded-For header in printed es logs \\(\"XFF\"\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "X-Forwarded-For header in printed es logs (\"XFF\")"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** kibana_index: \".kibana_@{user}\" when user is \"John Doe\" becomes .kibana\\_john\\_doe"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "kibana_index: \".kibana_@{user}\" when user is \"John Doe\" becomes .kibana\\_john\\_doe"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enteprise
     # original: "* **🐞Fix** \\(Enteprise\\) parse SAML groups from assertion as array of strings"
@@ -1244,23 +1244,23 @@ entries:
     components_raw: "PRO/Enteprise"
     text: "compatibility problems with OSS Kibana version ### What's new in 1.16.32"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** \"kibanaIndexTemplate\": default dashboards and spaces for new tenants"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "\"kibanaIndexTemplate\": default dashboards and spaces for new tenants"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.4"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.5.4"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Upgraded LDAP library"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Upgraded LDAP library"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise
     # original: "* **🧐Enhancement** \\(Enterprise\\) Now tenants save their CSV exports in their own reporting index"
@@ -1280,23 +1280,23 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "Now reporting works again ### What's new in 1.16.31"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.2, 6.5.3"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.5.2, 6.5.3"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: unknown_type
     # original: "* **🚧WIP**: Laid out the foundation for LDAP HA support ### What's new in 1.16.29"
     type: <unknown>
-    components_raw: ""
-    text: ""
+    components_raw: "unspecified"
+    text: ": Laid out the foundation for LDAP HA support ### What's new in 1.16.29"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.3"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.3"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🚀New Feature** \\(PRO/Enterprise\\) configurable server side session duration"
@@ -1304,17 +1304,17 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "configurable server side session duration"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** \\[LDAP\\] High Availability: Round Robin or Failover ### What's new in 1.16.28"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "\\[LDAP\\] High Availability: Round Robin or Failover ### What's new in 1.16.28"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.2"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.2"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise
     # original: "* **🐞Fix** \\(Enterprise\\) Multi tenancy: sometimes changing tenancy would not change kibana index"
@@ -1340,41 +1340,41 @@ entries:
     components_raw: "Enterprise/PRO"
     text: "Clear transient authentication cookies on login error to avoid authentication deadlocks"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞Fix**: External JWT verification may throw ArrayOutOfBoundException"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: ": External JWT verification may throw ArrayOutOfBoundException"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: unknown_type
     # original: "* **🚧WIP**: Laid out the foundation for internode SSL transport \\(port 9300\\) ### What's new in 1.16.27"
     type: <unknown>
-    components_raw: ""
-    text: ""
+    components_raw: "unspecified"
+    text: ": Laid out the foundation for internode SSL transport (port 9300) ### What's new in 1.16.27"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** \\[JWT\\] external validator: it's now possible to avoid storing the private key in settings"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "\\[JWT\\] external validator: it's now possible to avoid storing the private key in settings"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.1"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.1"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** SAML Single log out flow"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "SAML Single log out flow"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise,pro
     # original: "* **🐞Fix** \\(Enterprise/PRO\\) [cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB."
@@ -1394,17 +1394,17 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "bugs during plugin packaging and installation process ### What's new in 1.16.25"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** Users rule: easily restrict external authentication to a list of users"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Users rule: easily restrict external authentication to a list of users"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for ES 5.6.11"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES 5.6.11"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise,pro
     # original: "* **🐞Hot Fix** \\(Enterprise/PRO\\) Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24"
@@ -1418,23 +1418,23 @@ entries:
     components_raw: "Enterprise"
     text: "SAML Authentication"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** Support for Elasticsearch and Kibana 6.4.0"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch and Kibana 6.4.0"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature** Headers rule now split in headers\\_or and headers\\_and"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Headers rule now split in headers\\_or and headers\\_and"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Headers rule now allows wildcards"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Headers rule now allows wildcards"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise
     # original: "* **🚀New Feature** \\(Enterprise\\) Multi-tenancy now works also with JSON groups provider"
@@ -1442,17 +1442,17 @@ entries:
     components_raw: "Enterprise"
     text: "Multi-tenancy now works also with JSON groups provider"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞 Fix** Multi-tenancy \\(Enterprise\\) incoherent initial kibana\\_index and current group ### What's new in 1.16.23"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "Multi-tenancy (Enterprise) incoherent initial kibana\\_index and current group ### What's new in 1.16.23"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Support for Elastic Stack 6.3.1 and 5.6.10"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for Elastic Stack 6.3.1 and 5.6.10"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise
     # original: "* **🚀New Feature** \\(Enterprise\\) Custom CSS injection for Kibana"
@@ -1478,11 +1478,11 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature:**  map LDAP groups to local groups \\(a.k.a. role mapping\\)"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "map LDAP groups to local groups (a.k.a. role mapping)"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:elasticsearch
     # original: "* **🐞 Fix** \\(Elasticsearch\\) wildcard aliases resolution not working in \"indices\" rule."
@@ -1490,11 +1490,11 @@ entries:
     components_raw: "Elasticsearch"
     text: "wildcard aliases resolution not working in \"indices\" rule."
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement:** it is now possible now to use JDK 9 and 10"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "it is now possible now to use JDK 9 and 10"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:pro,enterprise
     # original: "* **🐞 Fix** \\(PRO/Enterprise\\) wait forever for login request \\(i.e.  slow LDAP servers\\)"
@@ -1520,11 +1520,11 @@ entries:
     components_raw: "PRO/Enterprise"
     text: "let RO users delete/edit search filters ### What's new in 1.16.21"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature:** Introducing support for Elasticsearch and Kibana v6.3.0"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: "Introducing support for Elasticsearch and Kibana v6.3.0"
   - # EDGE CASE — manual review needed
     # reason: unknown_component:enterprise
     # original: "* **🐞 Fix** \\(Enterprise\\) multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
@@ -1532,56 +1532,56 @@ entries:
     components_raw: "Enterprise"
     text: "multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐 Enhancement**: when login, forward \"elasticsearch.requestHeadersWhitelist\" headers. \\(useful for \"headers\" rule  and \"proxy\\_auth\" to work well.\\) ## ReadonlyREST for Elasticsearch"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: ": when login, forward \"elasticsearch.requestHeadersWhitelist\" headers. (useful for \"headers\" rule  and \"proxy\\_auth\" to work well.) ## ReadonlyREST for Elasticsearch"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀New Feature**: DLS \\(with dynamic variables suppoort\\) Thanks [DataSweet](http://www.datasweet.fr/)!"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: ": DLS (with dynamic variables suppoort) Thanks [DataSweet](http://www.datasweet.fr/)!"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀 New feature**: Field level security"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: ": Field level security"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🚀 New rules**: Snapshot, Repositories, Headers"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: new
+    components_raw: "unspecified"
+    text: ": Snapshot, Repositories, Headers"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐 Enhancement**: custom audit serializers: the request content is available"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: ": custom audit serializers: the request content is available"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞 Fix** readonlyrest.yml path discovery"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "readonlyrest.yml path discovery"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞 Fix:** LDAP available groups discovery \\(tenancy switcher\\) corner cases"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: "LDAP available groups discovery (tenancy switcher) corner cases"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞 Fix**: auth\\_key\\_sha1, auth\\_key\\_sha256 hashes in settings should be case insensitive"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: ": auth\\_key\\_sha1, auth\\_key\\_sha256 hashes in settings should be case insensitive"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🐞 Fix**: LDAP authentication didn't work with local group"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: fix
+    components_raw: "unspecified"
+    text: ": LDAP authentication didn't work with local group"

--- a/changelog/1.26.0.yaml
+++ b/changelog/1.26.0.yaml
@@ -1,3 +1,1587 @@
 version: "1.26.0"
 release_date: "2021-01-02"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) & [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) (removed Jackson dependency from ROR core)"
+  - type: new
+    components: [es]
+    text: "[New response\\_fields rule](https://forum.readonlyrest.com/t/ror-1-18-9-enterprise-es-7-2-0-enable-cluster-health-without-authentication/1567)"
+  - type: new
+    components: [es]
+    text: "[Support for LDAP server discovery using \\_ldaps.\\_tcp SRV record](https://forum.readonlyrest.com/t/does-ror-support-dc-locator/1211)"
+  - type: new
+    components: [es]
+    text: "[New configuration option allowing to ignore LDAP connectivity problems](https://forum.readonlyrest.com/t/ror-cannot-start-if-ldap-is-not-available/1748)"
+  - type: enhancement
+    components: [es]
+    text: "Full support for ILM API"
+  - type: enhancement
+    components: [kbn]
+    text: "Enforce read-after-write consistency between kibana nodes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) OIDC custom claims incorporated in \"assertion\" claim"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "OIDC custom claims incorporated in \"assertion\" claim"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) OIDC support for configurable kibanaExternalHost \\(good for Docker\\)"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "OIDC support for configurable kibanaExternalHost (good for Docker)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) ROR adds \"ror-user\\_\" class to \"body\" tag for easy per-user CSS/JS"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "ROR adds \"ror-user\\_\" class to \"body\" tag for easy per-user CSS/JS"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent,pro
+    # original: "* **🧐Enhancement** \\(KBN ENT/PRO\\) ROR adds \"ror-group\\_\" class to \"body\" tag for easy per-group CSS/JS"
+    type: enhancement
+    components_raw: "KBN ENT/PRO"
+    text: "ROR adds \"ror-group\\_\" class to \"body\" tag for easy per-group CSS/JS"
+  - type: fix
+    components: [es]
+    text: "[ROR authentication endpoint action](https://forum.readonlyrest.com/t/es-7-4-2-ror-1-18-9-rradmin-refreshsettings-by-block-default/1388)"
+  - type: fix
+    components: [es]
+    text: "\"username\" in audit entry when request is rejected ### What's new in 1.25.2"
+  - type: fix
+    components: [es]
+    text: "[removed verbose logging](https://forum.readonlyrest.com/t/elastic-message-cannot-extract-fields-for-query-after-readonlyrest-installation/1749) ### What's new in 1.25.1"
+  - type: security
+    components: [es]
+    text: "[CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)"
+  - type: new
+    components: [es]
+    text: "7.10.1 support ### What's new in 1.25.0"
+  - type: security
+    components: [es]
+    text: "[Common Vulnerabilities and Exposures (CVE)](https://forum.readonlyrest.com/t/update-of-jackson-databind-2-9-6-jar/176)"
+  - type: new
+    components: [es]
+    text: "7.10.0 support"
+  - type: new
+    components: [es]
+    text: "[auth\\_key\\_pbkdf2 rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#auth_key_pbkdf2)"
+  - type: new
+    components: [es]
+    text: "[Introduced configuration property defining FLS engine used by fields rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#fields)"
+  - type: enhancement
+    components: [es]
+    text: "Fields rule performance improvement"
+  - type: enhancement
+    components: [es]
+    text: "Resolved index API support"
+  - type: fix
+    components: [es]
+    text: "[\"username\" in audit entry when user is authenticated via proxy\\_auth](https://forum.readonlyrest.com/t/ror-audit-not-logging-user-id)"
+  - type: fix
+    components: [es]
+    text: "index resolve action should be treated as readonly action"
+  - type: fix
+    components: [es]
+    text: "/\\_snapshot and /\\_snapshot/\\_all should behave the same ### What's new in 1.24.0"
+  - type: security
+    components: [es]
+    text: "search template handling fix"
+  - type: new
+    components: [es]
+    text: "7.9.3 & 6.8.13 support"
+  - type: enhancement
+    components: [es]
+    text: "full support for ES Snapshots and Restore APIs"
+  - type: fix
+    components: [kbn]
+    text: "fix crash in error handling"
+  - type: fix
+    components: [es]
+    text: "don't remove ES response warning headers"
+  - type: fix
+    components: [es]
+    text: "issue when entropy of /dev/random could have been exhausted when using JwtToken rule ### What's new in 1.23.1"
+  - type: new
+    components: [es]
+    text: "7.9.2 support"
+  - type: fix
+    components: [kbn]
+    text: "fix code 500 error on login in Kibana ### What's new in 1.23.0"
+  - type: new
+    components: [es]
+    text: "introduced must\\_involve\\_indices option for indices rule"
+  - type: enhancement
+    components: [es]
+    text: "negation support in headers rules"
+  - type: enhancement
+    components: [es]
+    text: "[x-pack rollup API handling](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)"
+  - type: fix
+    components: [kbn]
+    text: "deep links query parameters are now handled"
+  - type: fix
+    components: [kbn]
+    text: "make sure default kibana index is always discovered (fixes reporting in 6.x)"
+  - type: fix
+    components: [es]
+    text: "[settings file permission issue with JDK 1.8.0 25.262-b10](https://forum.readonlyrest.com/t/readonlyrest-for-elastic-wont-start-1-18-8-es6-8-1/1652)"
+  - type: fix
+    components: [es]
+    text: "/\\_cluster/allocation/explain request should not be forbidden if matched block doesn't have indices rules"
+  - type: fix
+    components: [es]
+    text: "remote address extracting issue"
+  - type: fix
+    components: [es]
+    text: "[fixed TYP audit field for some request types](https://forum.readonlyrest.com/t/match-wrong-index-in-forbid-block/1653/2) ### What's new in 1.22.1"
+  - type: fix
+    components: [es]
+    text: "missing handling of aliases API for ES 7.9.0 ### What's new in 1.22.0"
+  - type: new
+    components: [es]
+    text: "7.9.0 support"
+  - type: enhancement
+    components: [es]
+    text: "aliases API handling"
+  - type: enhancement
+    components: [es]
+    text: "dynamic variables support in fields rule"
+  - type: fix
+    components: [es]
+    text: "[adding aliases issue](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)"
+  - type: fix
+    components: [es]
+    text: "potential memory leak for ES 7.7.x and above"
+  - type: fix
+    components: [es]
+    text: "cross cluster search issue fix for X-Pack \\_async\\_search action"
+  - type: fix
+    components: [es]
+    text: "XFF entry in audit issue"
+  - type: fix
+    components: [kbn]
+    text: "SAML certificate loading"
+  - type: fix
+    components: [kbn]
+    text: "SAML loading groups from assertion"
+  - type: fix
+    components: [kbn]
+    text: "fix reporting in pre-7.7.0 ### What's new in 1.21.0"
+  - type: enhancement
+    components: [es]
+    text: "[cluster API support improvements](https://forum.readonlyrest.com/t/settings-problems/1616)"
+  - type: fix
+    components: [es]
+    text: "X-Pack \\_async\\_search support"
+  - type: fix
+    components: [es]
+    text: "\\_rollover request handling"
+  - type: fix
+    components: [es]
+    text: "[handling numeric ssl configuration properties](https://forum.readonlyrest.com/t/numeric-passphrases-invalid-ssl-config/1512)"
+  - type: fix
+    components: [kbn]
+    text: "multitenancy+reporting regression fix (for 7.6.x and earlier)"
+  - type: fix
+    components: [kbn]
+    text: "\"x-\" headers should be forwarded in /login route when proxy passthrough is enabled"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** [\\(KBN\\) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: fix
+    components: [kbn]
+    text: "SAML metadata.xml endpoint not responding"
+  - type: fix
+    components: [kbn]
+    text: "NAT/reverse proxy support for SAML"
+  - type: fix
+    components: [kbn]
+    text: "SAML login redirect error"
+  - type: fix
+    components: [es]
+    text: "\\_readonlyrest/metadata/current\\_user should be always allowed by filter/fields rule ### What's new in 1.20.0"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** 7.7.1, 7.8.0 support"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: enhancement
+    components: [kbn]
+    text: "tidy up audit page"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn free
+    # original: "* **🧐Enhancement** \\(KBN FREE\\) clearly inform when features are not available"
+    type: enhancement
+    components_raw: "KBN FREE"
+    text: "clearly inform when features are not available"
+  - type: enhancement
+    components: [kbn]
+    text: "ship license report of libraries"
+  - type: enhancement
+    components: [es]
+    text: "filter rule performance improvement"
+  - type: fix
+    components: [kbn]
+    text: "proxy\\_auth: avoid logout-login loop"
+  - type: fix
+    components: [kbn]
+    text: "404 error on font CSS file"
+  - type: fix
+    components: [es]
+    text: "[wildcard in filter query issue](https://forum.readonlyrest.com/t/wildcard-in-dls-filter-gives-error/1551)"
+  - type: fix
+    components: [es]
+    text: "[forbidden /\\_snapshot issue](https://forum.readonlyrest.com/t/get-snapshot-permission-issue/1594)"
+  - type: fix
+    components: [es]
+    text: "/\\_mget handling by indices rule when no index from a list is found"
+  - type: fix
+    components: [es]
+    text: "available groups order in metadata response should match the order in which groups appear in ACL"
+  - type: fix
+    components: [es]
+    text: ".readonlyrest and audit index - removed usage of explicit index type"
+  - type: fix
+    components: [es]
+    text: "[tasks leak bug](https://forum.readonlyrest.com/t/lots-of-active-tasks-in-cat-tasks/1593) ### What's new in 1.19.5"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** 7.7.0, 7.6.2, 6.8.9, 6.8.8 support"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "kibana\\_access can be explicitly set to unrestricted"
+  - type: enhancement
+    components: [es]
+    text: "[LDAP connection pool improvement](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)"
+  - type: fix
+    components: [es]
+    text: "[better LDAP request timeout handling](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)"
+  - type: fix
+    components: [es]
+    text: "remote indices searching bug"
+  - type: fix
+    components: [es]
+    text: "cross cluster search support for \\_field\\_caps request"
+  - type: security
+    components: [es]
+    text: "create and delete templates handling"
+  - type: fix
+    components: [kbn]
+    text: "Regression in proxy\\_auth\\_passthrough"
+  - type: enhancement
+    components: [kbn]
+    text: "whitelistedPaths now accepts basic auth credentials"
+  - type: enhancement
+    components: [kbn]
+    text: "Dump logout button, [new ROR Panel](https://forum.readonlyrest.com/t/new-logout-button-design-new-ror-panel/1476)"
+  - type: enhancement
+    components: [kbn]
+    text: "removed ROR from Kibana sidebar. Admins have a link in new panel."
+  - type: enhancement
+    components: [kbn]
+    text: "avoid show login form redirecting from SAML IdP"
+  - type: new
+    components: [kbn]
+    text: "[OpenID Connect (OIDC) authentication connector](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#openid-connect-oidc)"
+  - type: new
+    components: [kbn]
+    text: "[login\\_title, login\\_subtitle enable 2 column login page](https://forum.readonlyrest.com/t/ror-enterprise-show-support-contact-on-login-page/1508/2)"
+  - type: security
+    components: [kbn]
+    text: "server-side navigation prevention to hidden apps ### What's new in 1.19.4"
+  - type: fix
+    components: [es]
+    text: "Interpolating config with environment variables in SSL section"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent 6.x
+    # original: "* **🐞Fix** \\(KBN Ent 6.x\\) Fixed default space creation in"
+    type: fix
+    components_raw: "KBN Ent 6.x"
+    text: "Fixed default space creation in"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) Fixed error toast notification not showing"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "Fixed error toast notification not showing"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🐞Fix** \\(KBN Ent\\) Fixed missing Axios dependency"
+    type: fix
+    components_raw: "KBN Ent"
+    text: "Fixed missing Axios dependency"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🐞Fix** \\(KBN Ent\\) Fixed SAML connector"
+    type: fix
+    components_raw: "KBN Ent"
+    text: "Fixed SAML connector"
+  - type: fix
+    components: [kbn]
+    text: "Toast notification overlap with logout bar"
+  - type: enhancement
+    components: [kbn]
+    text: "Restyled logout bar"
+  - type: enhancement
+    components: [kbn]
+    text: "Configurable periodic session checker ### What's new in 1.19.3"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "7.6.1 compatibility"
+  - type: new
+    components: [es]
+    text: "customizable name of settings index"
+  - type: enhancement
+    components: [kbn]
+    text: "configurable ROR cookie name"
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "handling of encoded ROR headers in Authorization header values"
+  - type: enhancement
+    components: [kbn]
+    text: "user feedback on why login failed"
+  - type: fix
+    components: [es]
+    text: "support for multiple header values"
+  - type: fix
+    components: [es]
+    text: "releasing LDAP connection pool on reloading ROR settings"
+  - type: fix
+    components: [kbn]
+    text: "multitenancy issue with 7.6.0+"
+  - type: fix
+    components: [kbn]
+    text: "creation of default space for new tenant"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) in RO mode, don't hide add/remove over fields in discovery"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "in RO mode, don't hide add/remove over fields in discovery"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) index template & in-index session manager issues ### What's new in 1.19.2"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "index template & in-index session manager issues ### What's new in 1.19.2"
+  - type: new
+    components: [kbn]
+    text: "7.6.0 support"
+  - type: enhancement
+    components: [kbn]
+    text: "less verbose info logging"
+  - type: enhancement
+    components: [kbn]
+    text: "start up time semantic check for settings"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn free
+    # original: "* **🐞Fix** \\(KBN Free\\) missing logout button"
+    type: fix
+    components_raw: "KBN Free"
+    text: "missing logout button"
+  - type: fix
+    components: [kbn]
+    text: "error message creating internal proxy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) add field to filter button invisible in RO mode ### What's new in 1.19.1"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "add field to filter button invisible in RO mode ### What's new in 1.19.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* **🎁Product** \\(KBN\\) [Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)"
+    type: <unknown>
+    components_raw: "KBN"
+    text: "[Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)"
+  - type: new
+    components: [es]
+    text: "7.6.0 support, Kibana support coming soon"
+  - type: new
+    components: [kbn]
+    text: "Audit log dashboard"
+  - type: new
+    components: [kbn]
+    text: "Template index can now be declared per tenant instead of globally"
+  - type: new
+    components: [es]
+    text: "custom trust store file and password options in ROR settings"
+  - type: enhancement
+    components: [es]
+    text: "When \"prompt\\_for\\_basic\\_auth\" is enabled, ROR is going to return 401 instead of 404 when the index is not found or a user is not allowed to see the index"
+  - type: enhancement
+    components: [es]
+    text: "literal ipv6 with zone Id is acceptable network address"
+  - type: enhancement
+    components: [es]
+    text: "LDAP client cache improvements"
+  - type: fix
+    components: [es]
+    text: "/\\_all/\\_settings API issue"
+  - type: fix
+    components: [es]
+    text: "Index stats API & Index shard stores API issue"
+  - type: fix
+    components: [es]
+    text: "readonlyrest.force\\_load\\_from\\_file setting decoding issue"
+  - type: fix
+    components: [kbn]
+    text: "allowing user to be logged in in two tabs at the same time"
+  - type: fix
+    components: [kbn]
+    text: "logging with JWT parameter issue"
+  - type: fix
+    components: [kbn]
+    text: "parsing of sessions fetched from ES index"
+  - type: fix
+    components: [kbn]
+    text: "logout issue ### What's new in 1.19.0"
+  - type: new
+    components: [kbn]
+    text: "Configurable option to delete docs from tenant index when not present in template"
+  - type: enhancement
+    components: [es]
+    text: "Less verbose logging of blocks history"
+  - type: enhancement
+    components: [es]
+    text: "Enriched logs and audit with attempted username"
+  - type: enhancement
+    components: [es]
+    text: "Better settings validation - only one authentication rule can be used in given block"
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Plugin versions printing in logs on launch"
+  - type: enhancement
+    components: [es]
+    text: "When user doesn't have access to given index, ROR pretends that the index doesn't exist and return 404 instead of 403"
+  - type: fix
+    components: [es]
+    text: "Searching for nonexistent/forbidden index with wildcard mirrors default ES behaviour instead of returning 403"
+  - type: fix
+    components: [kbn]
+    text: "Switching groups bug ### What's new in 1.18.10"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v6.8.6, v7.5.0, v7.5.1"
+  - type: new
+    components: [kbn]
+    text: "Group IDs can now be mapped to aliases"
+  - type: new
+    components: [es]
+    text: "New, more robust and simple method of creating custom audit log serializers"
+  - type: new
+    components: [es]
+    text: "Example projects with custom audit log serializers"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* 🐞**Fix** \\(KBN\\) Prevent index migration after kibana startup"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: enhancement
+    components: [kbn]
+    text: "If default space doesn't exist in kibana index then copy from default one"
+  - type: enhancement
+    components: [kbn]
+    text: "Crypto improvements - store init vector with encrypted data as base64 encoded json."
+  - type: enhancement
+    components: [es]
+    text: "Better settings validation - prevent duplicated keys in readonlyrest.yml ### What's new in 1.18.9"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.4.1, v7.4.2"
+  - type: new
+    components: [kbn]
+    text: "Kibana sessions stored in ES index"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* 🐞**Fix** \\(ES\\) issue with in-index settings auto-reloading"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* 🐞**Fix** \\(ES\\) \\_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.4.0"
+  - type: new
+    components: [es]
+    text: "Elasticsearch SQL Support"
+  - type: new
+    components: [es]
+    text: "Internode ssl support for es5x, es60x, es61x and es62x"
+  - type: new
+    components: [es]
+    text: "new runtime variable @{acl:current\\_group}"
+  - type: new
+    components: [es]
+    text: "namespace for user variable and support for both versions: @{user} and @{acl:user}"
+  - type: new
+    components: [es]
+    text: "support for multiple values in uri\\_re rule"
+  - type: enhancement
+    components: [es]
+    text: "more reliable in-index settings loading of ES with ROR startup"
+  - type: enhancement
+    components: [es]
+    text: "less verbose logs in JWT rules"
+  - type: enhancement
+    components: [es]
+    text: "Better response from ROR API when plugin is disabled"
+  - type: enhancement
+    components: [es]
+    text: "Splitting verification ssl property to client\\_authentication and certificate\\_verification"
+  - type: fix
+    components: [es]
+    text: "issue with backward compatibility of proxy\\_auth settings"
+  - type: fix
+    components: [es]
+    text: "/\\_render/template request NPE"
+  - type: fix
+    components: [es]
+    text: "\\_cat/indices API bug fixes"
+  - type: fix
+    components: [es]
+    text: "\\_cat/templates API return empty list instead of FORBIDDEN when no indices are found"
+  - type: fix
+    components: [es]
+    text: "updated regex for kibana access rule to support 7.3 ES"
+  - type: fix
+    components: [es]
+    text: "proper resolving of non-string ENV variables in readonlyrest.yml"
+  - type: fix
+    components: [es]
+    text: "lang-mustache search template handling ### What's new in 1.18.7"
+  - type: new
+    components: [es]
+    text: "Field level security (FLS) supports nested JSON fields"
+  - type: fix
+    components: [es]
+    text: "Authorization headers appeared in clear in logs"
+  - type: enhancement
+    components: [kbn]
+    text: "Don't logout users when they are not allowed to search a index-pattern"
+  - type: enhancement
+    components: [es]
+    text: "Headers obfuscation is now case insensitive ### What's new in 1.18.6"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.3.1, v7.3.2"
+  - type: new
+    components: [es]
+    text: "Configurable header names whose value should be obfuscated in logs"
+  - type: new
+    components: [kbn]
+    text: "Dynamic variables from user identity available in custom\\_logout\\_link"
+  - type: enhancement
+    components: [es]
+    text: "Richer logs for JWT errors"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🧐Enhancement** \\(ENT\\) nextUrl works also with SAML now"
+    type: enhancement
+    components_raw: "ENT"
+    text: "nextUrl works also with SAML now"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🧐Enhancement** \\(ENT\\) SAML assertion object available in ACL dynamic variables"
+    type: enhancement
+    components_raw: "ENT"
+    text: "SAML assertion object available in ACL dynamic variables"
+  - type: enhancement
+    components: [kbn]
+    text: "Validate LDAP server(s) before accepting new YAML settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Ensure a read-only UX for 'ro' users in older Kibana"
+  - type: fix
+    components: [es]
+    text: "Fix memory leak from dependency (snakeYAML) ### What's new in 1.18.5"
+  - type: fix
+    components: [es]
+    text: "indices rule can now properly handle also the templates API"
+  - type: enhancement
+    components: [es]
+    text: "Array dynamic variables are serialized as CSV wrapped in double quotes"
+  - type: enhancement
+    components: [es]
+    text: "Cleaner debug logs (no stacktraces on forbidden requests)"
+  - type: enhancement
+    components: [es]
+    text: "LDAP debug logs fire also when cache is hit"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.2.1, v7.3.0"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro
+    # original: "* **🐞Fix** \\(PRO\\) PRO plugin crashing for some Kibana versions"
+    type: fix
+    components_raw: "PRO"
+    text: "PRO plugin crashing for some Kibana versions"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) SAML library wrote a too large cookie sometimes"
+    type: fix
+    components_raw: "ENT"
+    text: "SAML library wrote a too large cookie sometimes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) SAML logout not working"
+    type: fix
+    components_raw: "ENT"
+    text: "SAML logout not working"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) JWT fix exception \"cannot set requestHeadersWhitelist\""
+    type: fix
+    components_raw: "ENT"
+    text: "JWT fix exception \"cannot set requestHeadersWhitelist\""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Hide more UI elements for RO users"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Hide more UI elements for RO users"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Sometimes not all the available groups appear in tenancy selector"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Sometimes not all the available groups appear in tenancy selector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Feature \"nextUrl\" broke"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Feature \"nextUrl\" broke"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) prevent user kick-out when APM is not configured and you are not an admin"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "prevent user kick-out when APM is not configured and you are not an admin"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🚀New** \\(PRO/ENT\\) Kibana request path/method now sent to ES \\(good for policing dev-tools\\) ### What's new in 1.18.4"
+    type: new
+    components_raw: "PRO/ENT"
+    text: "Kibana request path/method now sent to ES (good for policing dev-tools) ### What's new in 1.18.4"
+  - type: new
+    components: [es]
+    text: "User impersonation API"
+  - type: new
+    components: [es]
+    text: "Support latest 6.x and 5.x versions"
+  - type: fix
+    components: [es]
+    text: "filter/fields rules leak"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) allow more action for kibana\\_access, prevent sudden logout"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "allow more action for kibana\\_access, prevent sudden logout"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) temporarily roll back \"support for unlimited tenancies\" ### What's new in 1.18.3"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "temporarily roll back \"support for unlimited tenancies\" ### What's new in 1.18.3"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support added for ES/Kibana 6.8.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: enhancement
+    components: [es]
+    text: "Crash ES on invalid settings instead of stalling forever"
+  - type: enhancement
+    components: [es]
+    text: "Better logging on JWT, JSON-paths, LDAP, YAML errors"
+  - type: enhancement
+    components: [es]
+    text: "Block level settings validation to user with precious hints"
+  - type: enhancement
+    components: [es]
+    text: "If force\\_load\\_from\\_file: true, don't poll index settings"
+  - type: enhancement
+    components: [es]
+    text: "Order now counts declaring LDAP Failover HA servers"
+  - type: fix
+    components: [es]
+    text: "\"EsIndexJsonContentProvider\" had a null pointer exception"
+  - type: fix
+    components: [es]
+    text: "\"es.set.netty.runtime.available.processors\" exception"
+  - type: enhancement
+    components: [kbn]
+    text: "Collapsible logout button"
+  - type: enhancement
+    components: [kbn]
+    text: "ROR App now uses a HA http client"
+  - type: enhancement
+    components: [kbn]
+    text: "Automatic logout for inactivity"
+  - type: enhancement
+    components: [kbn]
+    text: "Support unlimited amount of tenancies"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) concurrent multitenancy bug"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "concurrent multitenancy bug"
+  - type: fix
+    components: [kbn]
+    text: "Avoid sporadic errors on Save/Load buttons ### What's new in 1.18.2"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support for Elasticsearch & Kibana 7.2.0"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: fix
+    components: [es]
+    text: "restore indices (\"IDX\") in audit logging"
+  - type: enhancement
+    components: [es]
+    text: "New algorithm of setting evaluation order"
+  - type: new
+    components: [es]
+    text: "JWT claims as dynamic variables. I.e. \"@{jwt:claim.json.path}\""
+  - type: new
+    components: [es]
+    text: "\"explode\" dynamic variables. I.e. indices: \\[\"@explode{x-indices}\"\\]"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) preserve comments and formatting in YAML editor"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "preserve comments and formatting in YAML editor"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Print error message when session is expired"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Print error message when session is expired"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Regression** \\(PRO/Enterprise\\) Redirect to original link after login"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Redirect to original link after login"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Regression** \\(PRO/Enterprise\\) Broken CSV reporting"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Broken CSV reporting"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) Prevent navigating away from YAML editor w/ unsaved changes"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "Prevent navigating away from YAML editor w/ unsaved changes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Exception when SAML connectors were all disabled"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Exception when SAML connectors were all disabled"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Concurrent tenants could mix up each other kibana index"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Concurrent tenants could mix up each other kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Cannot inject custom JS if no custom CSS was also declared"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Cannot inject custom JS if no custom CSS was also declared"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Injected JS had no effect on ROR logout button"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Injected JS had no effect on ROR logout button"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) On narrow screens, the YAML editor showed buttons twice ### What's new in 1.18.1"
+    type: fix
+    components_raw: "Enterprise"
+    text: "On narrow screens, the YAML editor showed buttons twice ### What's new in 1.18.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) Reindex requests failed for a regression in indices extraction"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "Reindex requests failed for a regression in indices extraction"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) Groups rule erratically failed"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "Groups rule erratically failed"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) JWT claims can now contain special characters"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "JWT claims can now contain special characters"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) Better ACL History logging"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "Better ACL History logging"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) QueryLogSerializer and old custom log serializers work again"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "QueryLogSerializer and old custom log serializers work again"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) ReadonlyREST icon in Kibana was white on white"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "ReadonlyREST icon in Kibana was white on white"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) SAML connectors could not be disabled"
+    type: fix
+    components_raw: "Enterprise"
+    text: "SAML connectors could not be disabled"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) SAML connector \"buttonName\" didn't work ### What's new in 1.18.0"
+    type: fix
+    components_raw: "Enterprise"
+    text: "SAML connector \"buttonName\" didn't work ### What's new in 1.18.0"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support for Elasticsearch & Kibana 7.0.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) empty array values in settings are invalid"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "empty array values in settings are invalid"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Security Fix** \\(Elasticsearch\\) arbitrary x-cluster search referencing local cluster"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "arbitrary x-cluster search referencing local cluster"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) ArrayOutOfBoundException on snapshot operations"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "ArrayOutOfBoundException on snapshot operations"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) History cleaning can now be disabled \\(\"clearSessionOnEvents\"\\) ### What's new in 1.17.7"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "History cleaning can now be disabled (\"clearSessionOnEvents\") ### What's new in 1.17.7"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support for Elasticsearch 7.0.0 \\(Kibana is coming soon\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) rewritten LDAP connector"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "rewritten LDAP connector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) new core written in Scala is now GA"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "new core written in Scala is now GA"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) devtools requests now honor the currently selected tenancy"
+    type: fix
+    components_raw: "Enterprise"
+    text: "devtools requests now honor the currently selected tenancy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Fix \"connectorsService\" error in installation ### What's new in 1.17.5"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Fix \"connectorsService\" error in installation ### What's new in 1.17.5"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,gt;= kibana 6.6.0
+    # original: "* **🧐Enhancement** \\(Enterprise &gt;= Kibana 6.6.0\\) Multiple SAML identity provider"
+    type: enhancement
+    components_raw: "Enterprise &gt;= Kibana 6.6.0"
+    text: "Multiple SAML identity provider"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Don't pass auth headers back to the browser"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Don't pass auth headers back to the browser"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Fix** \\(Enterprise/PRO\\) Missing null check caused error in reporting \\(CSV\\)"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Missing null check caused error in reporting (CSV)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Don't reject requests if SAML groups are not configured"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Don't reject requests if SAML groups are not configured"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** filter/fields rules not working in msearch \\(in 6.7.x\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Print whole LDAP search query in debug log ### What's new in 1.17.4"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.0"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) JWT query param is the preferred credentials provider"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "JWT query param is the preferred credentials provider"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) admin users can use indices management"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "admin users can use indices management"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) ro users can dismiss telemetry form"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "ro users can dismiss telemetry form"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** unpredictable behaviour of \"filter\" and \"fields\" when using external auth"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** LDAP ConcurrentModificationException"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Tenancy selector showing if user belonged to one group"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Tenancy selector showing if user belonged to one group"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) RW buttons not hiding for RO users in React Kibana apps"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "RW buttons not hiding for RO users in React Kibana apps"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Tenancy templating now works much more reliably"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Tenancy templating now works much more reliably"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Missing tenancy selector icon after switching tenancy"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Missing tenancy selector icon after switching tenancy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) barring static files requests caused sudden logout"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "barring static files requests caused sudden logout"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Numerous fixes to better support Kibana 6.6.x"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Critical fixes in new Scala core"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Exception in reindex requests caused tenancy templating to fail"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) SAML now works well in 6.6.x"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "SAML now works well in 6.6.x"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) \"undefined\" authentication error before login"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "\"undefined\" authentication error before login"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Default space creation failures for new tenants"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Default space creation failures for new tenants"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Icons/titles CSS misalignment in sidebar \\(Firefox\\)"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Icons/titles CSS misalignment in sidebar (Firefox)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🧐Enhancement**\\(Enterprise\\) UX: Larger tenancy selector"
+    type: enhancement
+    components_raw: "Enterprise"
+    text: "UX: Larger tenancy selector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Security Fix** \\(Enterprise\\) Privilege escalation when changing tenancies under monitoring"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Privilege escalation when changing tenancies under monitoring"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) compatibility fixes to support new Kibana features"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "compatibility fixes to support new Kibana features"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancements** \\(Elasticsearch\\) New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** Support for Kibana/Elasticsearch 6.6.0, 6.6.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** Internode SSL \\(ES 6.3.x onwards\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement**\\(PRO/Enterprise\\) UI appearence"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "UI appearence"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Made HTTP Connection configurable \\(PR \\#410\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** slow boot due to SecureRandom waiting for sufficient entropy"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix** Enable kibana\\_access:ro to create short urls in es6.3+ \\(PR \\#408\\) ### What's new in 1.16.34"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** X-Forwarded-For header in printed es logs \\(\"XFF\"\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** kibana_index: \".kibana_@{user}\" when user is \"John Doe\" becomes .kibana\\_john\\_doe"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🐞Fix** \\(Enteprise\\) parse SAML groups from assertion as array of strings"
+    type: fix
+    components_raw: "Enteprise"
+    text: "parse SAML groups from assertion as array of strings"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🐞Fix** \\(Enteprise\\) SAMLRequest in location header was URLEncoded twice, broke on some IdP"
+    type: fix
+    components_raw: "Enteprise"
+    text: "SAMLRequest in location header was URLEncoded twice, broke on some IdP"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix** \\(PRO/Enteprise\\) \"cookiePass\" works again, no more need for sticky cookies in load balancers!"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "\"cookiePass\" works again, no more need for sticky cookies in load balancers!"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix** \\(PRO/Enteprise\\) fix redirect loop with JWT deep linking when JWT token expires"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "fix redirect loop with JWT deep linking when JWT token expires"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🧐Enhancement** \\(PRO/Enteprise\\) fix audit demo page CSS"
+    type: enhancement
+    components_raw: "PRO/Enteprise"
+    text: "fix audit demo page CSS"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🧐Enhancement** \\(Enteprise\\) SAML more configuration parameters available"
+    type: enhancement
+    components_raw: "Enteprise"
+    text: "SAML more configuration parameters available"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🚀New Feature** \\(PRO/Enteprise\\) set ROR to debug mode \\(readonlyrest\\_kbn.logLevel: \"debug\"\\) ### What's new in 1.16.33"
+    type: new
+    components_raw: "PRO/Enteprise"
+    text: "set ROR to debug mode (readonlyrest\\_kbn.logLevel: \"debug\") ### What's new in 1.16.33"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) compatibility problems with older Kibana versions"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "compatibility problems with older Kibana versions"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) compatibility problems with OSS Kibana version ### What's new in 1.16.32"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "compatibility problems with OSS Kibana version ### What's new in 1.16.32"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** \"kibanaIndexTemplate\": default dashboards and spaces for new tenants"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.4"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Upgraded LDAP library"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🧐Enhancement** \\(Enterprise\\) Now tenants save their CSV exports in their own reporting index"
+    type: enhancement
+    components_raw: "Enterprise"
+    text: "Now tenants save their CSV exports in their own reporting index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) Support passwords that start and/or end with spaces"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "Support passwords that start and/or end with spaces"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Now reporting works again ### What's new in 1.16.31"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Now reporting works again ### What's new in 1.16.31"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.2, 6.5.3"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚧WIP**: Laid out the foundation for LDAP HA support ### What's new in 1.16.29"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.3"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🚀New Feature** \\(PRO/Enterprise\\) configurable server side session duration"
+    type: new
+    components_raw: "PRO/Enterprise"
+    text: "configurable server side session duration"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** \\[LDAP\\] High Availability: Round Robin or Failover ### What's new in 1.16.28"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.2"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Multi tenancy: sometimes changing tenancy would not change kibana index"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Multi tenancy: sometimes changing tenancy would not change kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Avoid echoing Base64 encoded credentials in login form error message"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Avoid echoing Base64 encoded credentials in login form error message"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) Remove latest search/visualization/dashboard history on logout"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "Remove latest search/visualization/dashboard history on logout"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) Clear transient authentication cookies on login error to avoid authentication deadlocks"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "Clear transient authentication cookies on login error to avoid authentication deadlocks"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞Fix**: External JWT verification may throw ArrayOutOfBoundException"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚧WIP**: Laid out the foundation for internode SSL transport \\(port 9300\\) ### What's new in 1.16.27"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** \\[JWT\\] external validator: it's now possible to avoid storing the private key in settings"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.1"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** SAML Single log out flow"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Fix** \\(Enterprise/PRO\\) [cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB."
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "[cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB."
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) much faster logout ### What's new in 1.16.26"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "much faster logout ### What's new in 1.16.26"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) bugs during plugin packaging and installation process ### What's new in 1.16.25"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "bugs during plugin packaging and installation process ### What's new in 1.16.25"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** Users rule: easily restrict external authentication to a list of users"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for ES 5.6.11"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Hot Fix** \\(Enterprise/PRO\\) Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) SAML Authentication"
+    type: new
+    components_raw: "Enterprise"
+    text: "SAML Authentication"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** Support for Elasticsearch and Kibana 6.4.0"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature** Headers rule now split in headers\\_or and headers\\_and"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Headers rule now allows wildcards"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Multi-tenancy now works also with JSON groups provider"
+    type: new
+    components_raw: "Enterprise"
+    text: "Multi-tenancy now works also with JSON groups provider"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞 Fix** Multi-tenancy \\(Enterprise\\) incoherent initial kibana\\_index and current group ### What's new in 1.16.23"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Support for Elastic Stack 6.3.1 and 5.6.10"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Custom CSS injection for Kibana"
+    type: new
+    components_raw: "Enterprise"
+    text: "Custom CSS injection for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Custom Javascript injection for Kibana"
+    type: new
+    components_raw: "Enterprise"
+    text: "Custom Javascript injection for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🚀New Feature** \\(PRO/Enterprise\\) access paths without need to login \\(i.e. /api/status\\)"
+    type: new
+    components_raw: "PRO/Enterprise"
+    text: "access paths without need to login (i.e. /api/status)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature:**  map LDAP groups to local groups \\(a.k.a. role mapping\\)"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞 Fix** \\(Elasticsearch\\) wildcard aliases resolution not working in \"indices\" rule."
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "wildcard aliases resolution not working in \"indices\" rule."
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement:** it is now possible now to use JDK 9 and 10"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) wait forever for login request \\(i.e.  slow LDAP servers\\)"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "wait forever for login request (i.e.  slow LDAP servers)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) add spinner and block UI if login request is being sent"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "add spinner and block UI if login request is being sent"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) if user is logged out because of LDAP cache expiring + slow authentication, redirect to login."
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "if user is logged out because of LDAP cache expiring + slow authentication, redirect to login."
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) let RO users delete/edit search filters ### What's new in 1.16.21"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "let RO users delete/edit search filters ### What's new in 1.16.21"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature:** Introducing support for Elasticsearch and Kibana v6.3.0"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞 Fix** \\(Enterprise\\) multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
+    type: fix
+    components_raw: "Enterprise"
+    text: "multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐 Enhancement**: when login, forward \"elasticsearch.requestHeadersWhitelist\" headers. \\(useful for \"headers\" rule  and \"proxy\\_auth\" to work well.\\) ## ReadonlyREST for Elasticsearch"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀New Feature**: DLS \\(with dynamic variables suppoort\\) Thanks [DataSweet](http://www.datasweet.fr/)!"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀 New feature**: Field level security"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🚀 New rules**: Snapshot, Repositories, Headers"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐 Enhancement**: custom audit serializers: the request content is available"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞 Fix** readonlyrest.yml path discovery"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞 Fix:** LDAP available groups discovery \\(tenancy switcher\\) corner cases"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞 Fix**: auth\\_key\\_sha1, auth\\_key\\_sha256 hashes in settings should be case insensitive"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🐞 Fix**: LDAP authentication didn't work with local group"
+    type: <unknown>
+    components_raw: ""
+    text: ""

--- a/changelog/1.26.1.yaml
+++ b/changelog/1.26.1.yaml
@@ -1,3 +1,6 @@
 version: "1.26.1"
 release_date: "2021-01-11"
 entries:
+  - type: fix
+    components: [es]
+    text: "wrong behaviour of `kibana_access` rule for ROR actions when ADMIN value is set"

--- a/changelog/1.27.0.yaml
+++ b/changelog/1.27.0.yaml
@@ -1,3 +1,21 @@
 version: "1.27.0"
 release_date: "2021-02-16"
 entries:
+  - type: new
+    components: [es]
+    text: "7.11.0, 7.10.2, 6.8.14 support"
+  - type: enhancement
+    components: [kbn]
+    text: "X-Forwarded-For copied from incoming request (or filled with source IP) before forwarding to ES"
+  - type: enhancement
+    components: [kbn]
+    text: "Kibana logout event generates a special audit log entry in ROR audit logs index"
+  - type: enhancement
+    components: [kbn]
+    text: "ROR panel shows \"reports\" button if kibana:management app is hidden"
+  - type: fix
+    components: [es]
+    text: "[blocks containing filter and/or fields won't match internal kibana requests, so kibana\\_\\* rules won't have to be placed in such blocks](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#fields)"
+  - type: fix
+    components: [es]
+    text: "SQL API - better handling of invalid query"

--- a/changelog/1.27.1.yaml
+++ b/changelog/1.27.1.yaml
@@ -1,3 +1,9 @@
 version: "1.27.1"
 release_date: "2021-02-27"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290)"
+  - type: new
+    components: [es]
+    text: "7.11.1 support"

--- a/changelog/1.28.0.yaml
+++ b/changelog/1.28.0.yaml
@@ -1,3 +1,27 @@
 version: "1.28.0"
 release_date: "2021-03-14"
 entries:
+  - type: new
+    components: [es]
+    text: "7.12.0, 7.11.2 support"
+  - type: new
+    components: [es]
+    text: "full [Index and Component Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/index-templates.html) support"
+  - type: enhancement
+    components: [es]
+    text: "[Username case sensitivity settings](https://forum.readonlyrest.com/t/ldap-based-user-authentication/1667)"
+  - type: fix
+    components: [es]
+    text: "[Kibana logout event storing fix](https://forum.readonlyrest.com/t/kibana-plugin-software-licensing-and-expiration/1808/5)"
+  - type: fix
+    components: [es]
+    text: "[Fixed remote reindex operation with \"type\" parameter](https://forum.readonlyrest.com/t/reindex-index-not-found-exception/1708/20)"
+  - type: fix
+    components: [kbn]
+    text: "Prevent cookie expiration deadlock in browsers when using SAML/OIDC"
+  - type: fix
+    components: [kbn]
+    text: "When credentials change in the ACL, make it possible to login again"
+  - type: fix
+    components: [kbn]
+    text: "Kibana management app ID changed from \"kibana:management\" to \"kibana:stack\\_management\""

--- a/changelog/1.28.1.yaml
+++ b/changelog/1.28.1.yaml
@@ -1,3 +1,9 @@
 version: "1.28.1"
 release_date: "2021-03-24"
 entries:
+  - type: fix
+    components: [es]
+    text: "Getting index templates issue when no `indices` rule was used in matched block"
+  - type: fix
+    components: [es]
+    text: "[NPE on getting template aliases](https://forum.readonlyrest.com/t/cannot-put-index-template-template-1/1681/25)"

--- a/changelog/1.28.2.yaml
+++ b/changelog/1.28.2.yaml
@@ -1,3 +1,9 @@
 version: "1.28.2"
 release_date: "2021-04-01"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295)"
+  - type: fix
+    components: [kbn]
+    text: "prevent SAML/OIDC initiated Kibana sessions from expiring after `session_timeout_minutes` despite continued interaction"

--- a/changelog/1.29.0.yaml
+++ b/changelog/1.29.0.yaml
@@ -1,3 +1,15 @@
 version: "1.29.0"
 release_date: "2021-04-09"
 entries:
+  - type: security
+    components: [es]
+    text: "Security Fix (ES) [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409)"
+  - type: new
+    components: [kbn]
+    text: "support 7.9.0, 7.9.1, 7.10.0, 7.10.1, 7.10.2, 7.11.0, 7.11.1, 7.11.2 ([with ROR new platform](https://beta.readonlyrest.com/))"
+  - type: new
+    components: [es]
+    text: "7.12.1 support"
+  - type: enhancement
+    components: [kbn]
+    text: "logout if the credentials/metadata of the current user change in the ACL"

--- a/changelog/1.30.0.yaml
+++ b/changelog/1.30.0.yaml
@@ -1,3 +1,36 @@
 version: "1.30.0"
 release_date: "2021-05-16"
 entries:
+  - type: new
+    components: [kbn]
+    text: "7.12.x compatibility"
+  - type: new
+    components: [es]
+    text: "[LDAP connector circuit breaker](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#circuit-breaker)"
+  - type: enhancement
+    components: [es]
+    text: "[Username with wildcard support in users section](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#groups) and [groups mapping](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#group-mapping)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) OIDC errors visibility"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "OIDC errors visibility"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) Smarter session probe algorithm"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "Smarter session probe algorithm"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:gt;= 7.9.x
+    # original: "* **🐞Fix** \\(KBN &gt;= 7.9.x\\) [Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)"
+    type: fix
+    components_raw: "KBN &gt;= 7.9.x"
+    text: "[Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) Don't hide visualizations list search box in RO mode"
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "Don't hide visualizations list search box in RO mode"

--- a/changelog/1.30.1.yaml
+++ b/changelog/1.30.1.yaml
@@ -1,3 +1,15 @@
 version: "1.30.1"
 release_date: "2021-05-26"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)"
+  - type: new
+    components: [es]
+    text: "7.13.0, 7.13.1 support"
+  - type: fix
+    components: [es]
+    text: "Regression in multi-tenancy handling"
+  - type: fix
+    components: [es]
+    text: "Proper handling of \\_snapshot/\\_status endpoint"

--- a/changelog/1.31.0.yaml
+++ b/changelog/1.31.0.yaml
@@ -1,3 +1,45 @@
 version: "1.31.0"
 release_date: "2021-06-29"
 entries:
+  - type: security
+    components: [kbn]
+    text: "prevent direct navigation to hidden apps"
+  - type: new
+    components: [es]
+    text: "7.13.4, 7.13.3, 7.13.2, 6.8.17 support"
+  - type: new
+    components: [kbn]
+    text: "new minimal Kibana Management menu when \"Management\" app is hidden"
+  - type: enhancement
+    components: [kbn]
+    text: "logout active Kibana session if key metadata/permissions change in ACL"
+  - type: enhancement
+    components: [kbn]
+    text: "better port number validation"
+  - type: enhancement
+    components: [es]
+    text: "improved cluster indices handling"
+  - type: fix
+    components: [es]
+    text: "[Kibana access rule regression fix](https://forum.readonlyrest.com/t/es7-11-2-1-30-0-enterprise-two-contexts-rw-ro-issue/1855)"
+  - type: fix
+    components: [es]
+    text: "search template API handling with `filter` and `fields` rule"
+  - type: fix
+    components: [es]
+    text: "multi-tenancy issue when groups_provider_authorization is used"
+  - type: fix
+    components: [es]
+    text: "`x_forwarded_for` rule: wrong handling of / request"
+  - type: fix
+    components: [es]
+    text: "Issue with handling ResizeRequest which made it unable to upgrade Kibana to version 7.12.0+"
+  - type: fix
+    components: [kbn]
+    text: "some Kibana requests arrive to ES without credentials"
+  - type: fix
+    components: [kbn]
+    text: "inconsistent read after write in session storage lead to issues with round robin load balancing"
+  - type: fix
+    components: [kbn]
+    text: "bad multipart POST handling leads to saved object import errors"

--- a/changelog/1.32.0.yaml
+++ b/changelog/1.32.0.yaml
@@ -1,3 +1,54 @@
 version: "1.32.0"
 release_date: "2021-07-25"
 entries:
+  - type: security
+    components: [es]
+    text: "[Apache Commons Codec vulnerability](https://forum.readonlyrest.com/t/security-vulnerability-for-common-codec-1-10/1906)"
+  - type: security
+    components: [kbn]
+    text: "upgraded dependencies due to security fixes"
+  - type: security
+    components: [kbn]
+    text: "disable x-powered-by to avoid fingerprinting"
+  - type: new
+    components: [es]
+    text: "Support for ES 7.14.0 & 6.8.18"
+  - type: new
+    components: [kbn]
+    text: "Support for Kibana 7.13.x series"
+  - type: enhancement
+    components: [kbn]
+    text: "honor configurations coming from ENV and CLI options"
+  - type: enhancement
+    components: [kbn]
+    text: "when metadata has no username, login must be denied"
+  - type: enhancement
+    components: [kbn]
+    text: "audit tab ported to new platform"
+  - type: enhancement
+    components: [es]
+    text: "improved ES resources cleaning when ROR returns FORBIDDEN response"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) auto clean-up dangling SAML/OIDC cookies"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "auto clean-up dangling SAML/OIDC cookies"
+  - type: fix
+    components: [es]
+    text: "[incomplete response for request GET */_alias](https://forum.readonlyrest.com/t/ror-return-incomplete-response-for-request-get-alias/1872)"
+  - type: fix
+    components: [es]
+    text: "not allowed aliases should not present in a response for a Get Index API request"
+  - type: fix
+    components: [kbn]
+    text: "fix dev-tools and import saved object not working"
+  - type: fix
+    components: [kbn]
+    text: "honor `requestHeadersWhitelist` in user metadata request (login)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) do not crash on invalid metadata  "
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "do not crash on invalid metadata"

--- a/changelog/1.33.0.yaml
+++ b/changelog/1.33.0.yaml
@@ -1,3 +1,24 @@
 version: "1.33.0"
 release_date: "2021-08-09"
 entries:
+  - type: security
+    components: [kbn]
+    text: "xml-crypto dependency update"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.14.0, 6.8.18"
+  - type: enhancement
+    components: [kbn]
+    text: "Parse credentials in /api/* requests, no need for valid cookie. Supersedes whitelistedPaths"
+  - type: fix
+    components: [kbn]
+    text: "Caching issues switching tenancies with dark/light theme"
+  - type: fix
+    components: [kbn]
+    text: "Newly created Space shows in all tenancies when using default kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) nextUrl works again with SAML and OIDC"
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "nextUrl works again with SAML and OIDC"

--- a/changelog/1.33.1.yaml
+++ b/changelog/1.33.1.yaml
@@ -1,3 +1,15 @@
 version: "1.33.1"
 release_date: "2021-08-14"
 entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.14.1"
+  - type: fix
+    components: [kbn]
+    text: "Error in patching for 7.14.0"
+  - type: fix
+    components: [kbn]
+    text: "clearSessionOnEvents now works as expected"
+  - type: fix
+    components: [kbn]
+    text: "login form font loads correctly"

--- a/changelog/1.34.0.yaml
+++ b/changelog/1.34.0.yaml
@@ -1,3 +1,27 @@
 version: "1.34.0"
 release_date: "2021-09-24"
 entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.0, 7.14.2"
+  - type: new
+    components: [kbn]
+    text: "VS Code style YAML editor"
+  - type: new
+    components: [kbn]
+    text: "Skip rendering hidden app groups entirely"
+  - type: new
+    components: [kbn]
+    text: "Redesigned ROR Menu"
+  - type: new
+    components: [kbn]
+    text: "Dark theme awareness"
+  - type: fix
+    components: [kbn]
+    text: "Broken Kibana Spaces"
+  - type: fix
+    components: [kbn]
+    text: "Support Kibana's undocumented \"server.ssl.*\" settings"
+  - type: fix
+    components: [kbn]
+    text: "cookiePass config parsing broke load balancing"

--- a/changelog/1.35.0.yaml
+++ b/changelog/1.35.0.yaml
@@ -1,3 +1,57 @@
 version: "1.35.0"
 release_date: "2021-10-12"
 entries:
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.0, 7.14.2"
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.1, 6.8.19, 6.8.20"
+  - type: enhancement
+    components: [es]
+    text: "[local->external groups detailed mapping for groups rule](https://github.com/beshu-tech/readonlyrest-docs/blob/master/details/groups-rule-mapping.md)"
+  - type: enhancement
+    components: [es]
+    text: "when ROR is starting any request is going to end up with HTTP 403 response, instead of HTTP 503"
+  - type: enhancement
+    components: [kbn]
+    text: "\"server.basePath\" kibana option implementation"
+  - type: enhancement
+    components: [kbn]
+    text: "Support full regex in kibana_hidden_apps rule"
+  - # EDGE CASE — manual review needed
+    # reason: regex_no_match
+    # original: "* **🧐Enhancement** Crash if Kibana is not patched"
+    type: <unknown>
+    components_raw: ""
+    text: ""
+  - type: enhancement
+    components: [kbn]
+    text: "Honour kibana setting \"logging.dest\""
+  - type: enhancement
+    components: [kbn]
+    text: "Confirm before overwriting audit log dashboard"
+  - type: fix
+    components: [es]
+    text: "verbosity: error fix in case of ROR KBN login request"
+  - type: fix
+    components: [kbn]
+    text: "Make alerting work on primary tenancy"
+  - type: fix
+    components: [kbn]
+    text: "OIDC fix sameSite / secure cookie options"
+  - type: fix
+    components: [kbn]
+    text: "Login form is stretched when long error"
+  - type: fix
+    components: [kbn]
+    text: "Login form is stretched when long error"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn-pro
+    # original: "* **🐞Fix** (KBN-PRO) [Don't send x-ror-currentgroup in PRO](https://forum.readonlyrest.com/t/upgrading-6-7-w-1-18-to-7-14-w-1-33-ldap-from-ms-active-directory-no-longer-understands-multiple-ad-group-memberships/1973/6)"
+    type: fix
+    components_raw: "KBN-PRO"
+    text: "[Don't send x-ror-currentgroup in PRO](https://forum.readonlyrest.com/t/upgrading-6-7-w-1-18-to-7-14-w-1-33-ldap-from-ms-active-directory-no-longer-understands-multiple-ad-group-memberships/1973/6)"
+  - type: fix
+    components: [kbn]
+    text: "Resolve browser console errors on a popover close"

--- a/changelog/1.35.0.yaml
+++ b/changelog/1.35.0.yaml
@@ -20,11 +20,11 @@ entries:
     components: [kbn]
     text: "Support full regex in kibana_hidden_apps rule"
   - # EDGE CASE — manual review needed
-    # reason: regex_no_match
+    # reason: no_component_specified
     # original: "* **🧐Enhancement** Crash if Kibana is not patched"
-    type: <unknown>
-    components_raw: ""
-    text: ""
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Crash if Kibana is not patched"
   - type: enhancement
     components: [kbn]
     text: "Honour kibana setting \"logging.dest\""


### PR DESCRIPTION
## Why

Phase 3 of the UI-for-Changelog cutover. Companion to:
- [beshu-tech/ror-api#86](https://github.com/beshu-tech/ror-api/issues/86) — tracker
- [beshu-tech/ror-api#91](https://github.com/beshu-tech/ror-api/pull/91) — webhook accepts new structured payload (already deployed to prod 2026-05-13, smoke test passed)
- [readonlyrest-docs#314](https://github.com/beshu-tech/readonlyrest-docs/pull/314) — 66-version YAML migration (merged)

**The merge of THIS PR is the actual cutover.** After merge:
- Maintainers file new changelog entries via Issue Forms instead of editing `changelog.md`
- `changelog.md` becomes auto-generated from `changelog/*.yaml`
- Webhook to ror-api uses new event-typed structured payload
- Non-maintainer issues auto-close

## What lands

### Workflows

| File | Purpose |
|---|---|
| `maintainer_gate.yml` | Close + lock changelog issues from non-OWNER/MEMBER/COLLABORATOR (<30s) |
| `changelog_form.yml` | Parse form → write `changelog/<version>.yaml` → open/refresh PR |
| `render_changelog.yml` | ajv schema validation + filename↔version check; on push to master, regen `changelog.md` |
| `changelog_watch.yml` | **MODIFIED** — fires on `changelog/*.yaml` changes, sends event-typed structured payload |

### Templates

- `.github/ISSUE_TEMPLATE/changelog-entry.yml` — 2-field form (version + notes textarea)
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues

### Schema + config

- `.github/schemas/changelog-entry.schema.json` — single source of YAML truth. Includes optional `components_raw` for hash parity with stored LLM descriptions.
- `.github/changelog-config.yml` — `auto_merge: false` (default). Flip to `true` once trusted to make form PRs auto-merge.

### Modified `changelog_watch.yml` payload

Before (`changelog.md` diff):
```json
{ "changelog_diff": "<git unified diff>" }
```

After (per-version event):
```json
{ "event": "version_added | version_modified | version_deleted",
  "version": "1.69.0",
  "yaml": "<full YAML content>" }
```

One POST per changed YAML in the push. ror-api PR #91 accepts both formats during 1-week dual-window (legacy `find_versions_affected` kept as fallback).

### Bot-authored render commits don't loop

`render_changelog.yml` pushes `changelog.md` regens back to master. `changelog_watch.yml` paths filter is `changelog/*.yaml` only → bot's `changelog.md` commits don't re-trigger the watch.

## Required repo settings (apply BEFORE merge)

These won't function without these — same settings already applied on `ton77v/changelog-forms-demo` (see [demo PLAN.md](https://github.com/ton77v/changelog-forms-demo/blob/main/PLAN.md)):

```bash
# Allow Actions to create PRs (form action needs this)
gh api -X PUT repos/beshu-tech/readonlyrest-docs/actions/permissions/workflow \
  -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true

# Auto-delete branches on merge + allow auto-merge
gh api -X PATCH repos/beshu-tech/readonlyrest-docs \
  -F allow_auto_merge=true -F delete_branch_on_merge=true
```

(Need admin permissions on the repo.)

## Verification after merge

1. File a test changelog issue from your maintainer account → expect:
   - `[Changelog X.Y.Z] <summary>` title (auto-renamed)
   - Bot PR opened against `master` with `changelog/X.Y.Z.yaml`
   - Comment on issue linking to PR
   - Issue auto-closed

2. File a test issue from a non-maintainer account → expect auto-close + lock <30s

3. Merge the bot's test PR → expect:
   - `changelog.md` regenerated by render workflow (auto-commit by `github-actions[bot]`)
   - `changelog_watch.yml` fires → POSTs new structured payload → ror-api receives + queues `try_release_update` for the version
   - Check ror-api prod logs: `just -g prod logs ror-portal --since 10m | grep -i changelog`

4. Delete a test YAML → render workflow regenerates `changelog.md` without it, watch sends `version_deleted` event, ror-api logs + skips.

## Rollback path

If anything regresses:
1. Revert this PR (single commit on master)
2. ror-api still accepts legacy `changelog_diff` payload (PR #91 kept the fallback)
3. Restore old `changelog_watch.yml` (the modified file is the only one with a prior version on master)

## Phase 4 (next, ~1 week later)

After 1 week of clean dual-window operation:
- Drop `find_versions_affected` + legacy `changelog_diff` branch in ror-api `update_changelog()`
- Drop `parse_changelog()` (line 65); rewire `parse_changelog_structured` to iterate YAMLs
- Retarget `detailed_changelog.py` source from MD parsing → YAML loading (keeps GitBook integration intact)

> <signature>🦀 **sent by Claude Code**</signature>