### PR TITLE
chore: sync master into develop (after Phase 3 cutover)

### DIFF
--- a/.github/ISSUE_TEMPLATE/changelog-entry.yml
+++ b/.github/ISSUE_TEMPLATE/changelog-entry.yml
@@ -1,0 +1,39 @@
+name: Changelog (maintainers only)
+description: Add changelog entries (one or many) — restricted to repo maintainers
+title: "[Changelog] (auto-renamed on submit)"
+labels: ["changelog-entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **🔒 Maintainers only.** Non-maintainer issues are auto-closed within ~30s by the [maintainer gate workflow](../blob/main/.github/workflows/maintainer_gate.yml). If you're not a maintainer, please use [Discussions](../../discussions) or contact the team directly.
+
+        Paste one line per entry — single or whole release, same form.
+
+        **Format:** `<type> (<component>) <text>` — same as `changelog.md` today
+
+        - **types:** `new`, `fix`, `security`, `warning`, `enhancement`
+        - **components:** `es`, `kbn`, `eck` — combinable: `es|kbn`, `kbn|eck`, `es|kbn|eck`
+        - text supports markdown links
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: "1.68.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      placeholder: |
+        new (es) 9.0.2, 8.18.2, 8.17.7 support
+        new (kbn) 9.0.2, 8.18.2, 8.17.7 support
+        fix (eck) Operator handling of TLS rotation
+        fix (es|kbn) tenancy selector with jwt_auth
+        security (es) CVE-2024-53382
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Source / discussion
+    url: https://github.com/beshu-tech/ror-api/issues/86
+    about: This is a demo for ror-api#86 — UI for Changelog

--- a/.github/changelog-config.yml
+++ b/.github/changelog-config.yml
@@ -1,0 +1,12 @@
+# Changelog form behavior.
+# Single source of truth — change via PR, never via repo UI.
+# Consumed by .github/workflows/changelog_form.yml.
+
+# When true: form-opened PRs are auto-merged once required status checks pass
+# (or immediately if no branch protection). When false: maintainer reviews + clicks merge.
+#
+# In prod, recommended rollout:
+#   1. Ship with auto_merge: false — team learns the loop by reviewing each PR manually
+#   2. Once trusted, flip to true via PR + add branch protection requiring `validate-and-render`
+#   3. For the gate to actually block on CI: bot needs a PAT (GITHUB_TOKEN-authored PRs skip CI)
+auto_merge: false

--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Changelog version",
+  "type": "object",
+  "required": ["version", "release_date", "entries"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-(rc|beta|alpha)\\d*)?$",
+      "description": "Semver; pre-release suffixes -rcN/-betaN/-alphaN allowed"
+    },
+    "release_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "text"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": ["string", "null"],
+            "description": "Canonical (new/fix/security/warning/enhancement) or arbitrary string for legacy entries that don't match a canonical type."
+          },
+          "components": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "enum": ["es", "kbn", "eck"] },
+            "description": "Canonical component(s). Required for new form-driven entries."
+          },
+          "components_raw": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Preserves original separator/order (e.g. 'KBN/ES', 'KBN ENT/PRO') for hash parity with ror-api stored LLM descriptions. Required when `components` is absent — used for legacy migration entries that don't map cleanly to canonical components."
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "anyOf": [
+          { "required": ["components"] },
+          { "required": ["components_raw"] }
+        ]
+      }
+    }
+  }
+}

--- a/.github/workflows/changelog_form.yml
+++ b/.github/workflows/changelog_form.yml
@@ -1,0 +1,249 @@
+name: Changelog form
+
+# Parses Issue Form body. On success: writes changelog/{version}.yaml and opens
+# (or refreshes) a PR via peter-evans/create-pull-request. On error: posts
+# updateable bot comment with parse errors. Title is auto-renamed once parsed.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  parse:
+    if: contains(github.event.issue.labels.*.name, 'changelog-entry')
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.parse.outputs.ok }}
+      version: ${{ steps.parse.outputs.version }}
+      yaml_path: ${{ steps.parse.outputs.yaml_path }}
+      pr_title: ${{ steps.parse.outputs.pr_title }}
+      commit_msg: ${{ steps.parse.outputs.commit_msg }}
+      branch: ${{ steps.parse.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse form, write YAML or post errors
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+            const body = context.payload.issue.body || ''
+            const marker = '<!-- changelog-form-bot -->'
+
+            // Issue Forms render: ### <Field>\n\n<value>\n\n### <Next>...
+            const sections = {}
+            let cur = null, buf = []
+            for (const line of body.split(/\r?\n/)) {
+              if (line.startsWith('### ')) {
+                if (cur) sections[cur] = buf.join('\n').trim()
+                cur = line.slice(4).trim()
+                buf = []
+              } else {
+                buf.push(line)
+              }
+            }
+            if (cur) sections[cur] = buf.join('\n').trim()
+
+            const version = (sections['Version'] || '').trim()
+            const stripFence = (s) => {
+              const lines = s.split(/\r?\n/)
+              if (lines[0] && /^```/.test(lines[0].trim())) lines.shift()
+              if (lines.length && /^```/.test((lines[lines.length - 1] || '').trim())) lines.pop()
+              return lines.join('\n')
+            }
+            const notes = stripFence((sections['Notes'] || '').trim()).trim()
+
+            const errors = []
+            if (!/^\d+\.\d+\.\d+(-(rc|beta|alpha)\d*)?$/.test(version)) {
+              errors.push(`Version must match X.Y.Z (optionally -rcN/-betaN/-alphaN) — got: \`${version}\``)
+            }
+            if (!notes) errors.push('Notes is empty')
+
+            const TYPE_MAP = {
+              new: 'new', feat: 'new', feature: 'new',
+              fix: 'fix', bugfix: 'fix',
+              security: 'security', 'security fix': 'security', sec: 'security',
+              warning: 'warning', warn: 'warning',
+              enhancement: 'enhancement', enh: 'enhancement', improve: 'enhancement',
+            }
+            // Components: es, kbn, eck — combinable via any of `|`, `/`, `&`, `,`, ` and `.
+            // Real changelog.md uses mixed separators (`KBN/ES`, `ES & KBN`, etc); we normalize.
+            // Canonical output order: es, kbn, eck (matches dominant pattern in existing changelog.md).
+            // Edge cases (~0.7%: `KBN-PRO`, `KBN < 7.9.x`) are rejected here → user edits YAML directly.
+            const COMP_ORDER = ['es', 'kbn', 'eck']
+            const parseComps = (raw) => {
+              const normalized = raw.toLowerCase().replace(/\s+and\s+/g, '|').replace(/[\/&,]/g, '|')
+              const parts = normalized.replace(/\s+/g, '').split('|').filter(Boolean)
+              if (!parts.length) return null
+              const unknown = parts.filter(p => !COMP_ORDER.includes(p))
+              if (unknown.length) return null
+              return COMP_ORDER.filter(c => parts.includes(c))
+            }
+
+            const entries = []
+            const lineRe = /^\s*(?<type>[\w ]+?)\s*\(\s*(?<comp>[^)]+?)\s*\)\s*:?\s*(?<text>.+?)\s*$/i
+
+            notes.split(/\r?\n/).forEach((raw, i) => {
+              const line = raw.trim()
+              if (!line || line.startsWith('#') || line.startsWith('//')) return
+              const m = line.match(lineRe)
+              if (!m) {
+                errors.push(`Line ${i + 1}: cannot parse \`${line}\` — expected \`<type> (<component>) <text>\``)
+                return
+              }
+              const type = TYPE_MAP[m.groups.type.toLowerCase()]
+              const comp = parseComps(m.groups.comp)
+              if (!type) errors.push(`Line ${i + 1}: unknown type \`${m.groups.type}\` — use one of: new, fix, security, warning, enhancement`)
+              if (!comp) errors.push(`Line ${i + 1}: unknown component \`${m.groups.comp}\` — use one of: es, kbn, eck (combinable with \`|\`, e.g. es|kbn)`)
+              if (type && comp) entries.push({ type, components: comp, text: m.groups.text })
+            })
+
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+            const findExisting = async () => {
+              const { data: comments } = await github.rest.issues.listComments(ref)
+              return comments.find(c => c.body && c.body.includes(marker))
+            }
+            const upsertComment = async (commentBody) => {
+              const existing = await findExisting()
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: ref.owner, repo: ref.repo, comment_id: existing.id, body: commentBody,
+                })
+              } else {
+                await github.rest.issues.createComment({ ...ref, body: commentBody })
+              }
+            }
+
+            if (errors.length) {
+              const errMsg = `${marker}\n**Could not parse** (${errors.length} issue${errors.length > 1 ? 's' : ''}):\n\n` +
+                errors.map(e => `- ${e}`).join('\n') +
+                `\n\n_Edit the issue body to fix — this comment will refresh._`
+              await upsertComment(errMsg)
+              core.setOutput('ok', 'false')
+              return
+            }
+
+            // Today is intentional — release date defaults to filing day; editable in PR.
+            // Dates and versions are ALWAYS quoted: js-yaml parses unquoted dates as Date
+            // objects, breaking ajv's `type: string` check.
+            const today = new Date().toISOString().slice(0, 10)
+            const yamlEsc = (s) => /[:#\[\]{}&*!|>'"%@`]|^\s|\s$/.test(s) ? JSON.stringify(s) : s
+            let yaml = `version: "${version}"\nrelease_date: "${today}"\nentries:\n`
+            for (const e of entries) {
+              yaml += `  - type: ${e.type}\n`
+              yaml += `    components: [${e.components.join(', ')}]\n`
+              yaml += `    text: ${yamlEsc(e.text)}\n`
+            }
+
+            const yamlPath = `changelog/${version}.yaml`
+            fs.mkdirSync(path.dirname(yamlPath), { recursive: true })
+            fs.writeFileSync(yamlPath, yaml)
+
+            const summary = entries.length === 1
+              ? `${entries[0].type} (${entries[0].components.join('|')}): ${entries[0].text}`.slice(0, 80)
+              : `${entries.length} entries`
+            const prTitle = `[Changelog ${version}] ${summary}`
+
+            if (context.payload.issue.title !== prTitle) {
+              await github.rest.issues.update({ ...ref, title: prTitle })
+            }
+
+            core.setOutput('ok', 'true')
+            core.setOutput('version', version)
+            core.setOutput('yaml_path', yamlPath)
+            core.setOutput('pr_title', prTitle)
+            core.setOutput('commit_msg', `Add changelog entry for ${version} (#${context.issue.number})`)
+            core.setOutput('branch', `changelog/v${version}-issue-${context.issue.number}`)
+
+      - name: Create or update PR
+        if: steps.parse.outputs.ok == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.parse.outputs.branch }}
+          base: master
+          title: ${{ steps.parse.outputs.pr_title }}
+          commit-message: ${{ steps.parse.outputs.commit_msg }}
+          body: |
+            Auto-opened from issue #${{ github.event.issue.number }}.
+
+            Render workflow will regenerate `changelog.md` on merge to `master`.
+
+            ---
+            _Edit the YAML directly in this PR to fix typos or update the release date._
+          delete-branch: true
+          add-paths: |
+            changelog/*.yaml
+
+      # Read changelog-form config (committed to repo at .github/changelog-config.yml).
+      # Adjusting auto_merge etc. = open a PR against the config file, not a UI flip.
+      - name: Read config
+        id: cfg
+        run: |
+          if [ -f .github/changelog-config.yml ]; then
+            echo "auto_merge=$(yq -r '.auto_merge // false' .github/changelog-config.yml)" >> "$GITHUB_OUTPUT"
+          else
+            echo "auto_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auto-merge toggle. Enable by setting `auto_merge: true` in .github/changelog-config.yml.
+      # With `--auto`, GitHub waits for required status checks (branch protection) before merging;
+      # if no checks required, merges immediately.
+      # CAVEAT: bot-authored PRs from GITHUB_TOKEN don't trigger CI (recursion guard).
+      # For a true "wait for green CI" gate in prod: use a PAT in the create-pr step above,
+      # AND set branch protection with validate-and-render required.
+      - name: Enable auto-merge
+        if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url && steps.cfg.outputs.auto_merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+
+      - name: Comment PR link on issue and close
+        if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url
+        uses: actions/github-script@v7
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_OP: ${{ steps.cpr.outputs.pull-request-operation }}
+          AUTOMERGE: ${{ steps.cfg.outputs.auto_merge }}
+        with:
+          script: |
+            const marker = '<!-- changelog-form-bot -->'
+            const op = process.env.PR_OP
+            const url = process.env.PR_URL
+            const automerge = process.env.AUTOMERGE === 'true'
+            const verb = op === 'created' ? 'Opened' : 'Updated'
+            const automergeNote = automerge
+              ? '\n\n_Auto-merge enabled (`.github/changelog-config.yml`) — will merge once required checks pass._'
+              : '\n\n_Edit the YAML directly in the PR for fixes. Merge will trigger `changelog.md` regen._'
+            const body = `${marker}\n${verb} ${url}${automergeNote}`
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+
+            const { data: comments } = await github.rest.issues.listComments(ref)
+            const existing = comments.find(c => c.body && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: ref.owner, repo: ref.repo, comment_id: existing.id, body,
+              })
+            } else {
+              await github.rest.issues.createComment({ ...ref, body })
+            }
+            if (op === 'created' && context.payload.issue.state === 'open') {
+              await github.rest.issues.update({ ...ref, state: 'closed', state_reason: 'completed' })
+            }

--- a/.github/workflows/changelog_watch.yml
+++ b/.github/workflows/changelog_watch.yml
@@ -1,37 +1,55 @@
 name: Watch Changelog
 
+# Phase 3+: fires on changelog/*.yaml changes (single source of truth).
+# Each changed YAML triggers an event-typed webhook to ror-api.
+# The legacy changelog.md push path is gone — changelog.md is now an auto-generated
+# mirror produced by render_changelog.yml. Bot-pushed regens don't trigger this workflow.
+
 on:
   push:
-    branches:  # may need to parameterize this
+    branches:
       - master
     paths:
-      - changelog.md
+      - "changelog/**.yaml"
 
 jobs:
-  on-changelog-update:
+  notify-ror-api:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need prev commit for diff
 
-      - name: Get changelog diff
-        id: changelog
+      - name: Detect changed YAMLs + send per-version webhooks
+        env:
+          API_KEY: ${{ secrets.DOCS_REPO_API_SECRET }}
+          WEBHOOK_URL: ${{ secrets.CHANGELOG_WEBHOOK_URL }}
         run: |
-          git fetch --deepen=1
-          PREV_COMMIT=$(git rev-parse HEAD~1 || echo "")
-          if [ -z "$PREV_COMMIT" ]; then
-            DIFF=$(cat changelog.md)
-          else
-            DIFF=$(git diff "$PREV_COMMIT" HEAD -- changelog.md)
-          fi
-          
-          echo "DIFF<<EOF" >> $GITHUB_ENV
-          echo "$DIFF" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Send webhook with changelog diff
-        run: |
-          curl --fail --retry 3 -X POST -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.DOCS_REPO_API_SECRET }}" \
-            -d "$(jq -nc --arg diff "$DIFF" '{"changelog_diff": $diff}')" \
-            ${{ secrets.CHANGELOG_WEBHOOK_URL }}
+          set -eo pipefail
+          PREV=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          # Each changed YAML => one event-typed POST. A/M/D classified by git status code.
+          git diff --name-status "$PREV" HEAD -- 'changelog/*.yaml' | while IFS=$'\t' read -r STATUS FILE; do
+            VERSION=$(basename "$FILE" .yaml)
+            case "$STATUS" in
+              A) EVENT="version_added" ;;
+              M) EVENT="version_modified" ;;
+              D) EVENT="version_deleted" ;;
+              *) echo "skip status=$STATUS file=$FILE" && continue ;;
+            esac
+            # Inline YAML content if file exists (skip for deletions)
+            if [ "$EVENT" != "version_deleted" ]; then
+              YAML_CONTENT=$(cat "$FILE")
+              PAYLOAD=$(jq -nc \
+                --arg event "$EVENT" --arg version "$VERSION" --arg yaml "$YAML_CONTENT" \
+                '{event: $event, version: $version, yaml: $yaml}')
+            else
+              PAYLOAD=$(jq -nc \
+                --arg event "$EVENT" --arg version "$VERSION" \
+                '{event: $event, version: $version}')
+            fi
+            echo "POST $EVENT $VERSION"
+            curl --fail --retry 3 -X POST -H "Content-Type: application/json" \
+              -H "x-api-key: $API_KEY" \
+              -d "$PAYLOAD" \
+              "$WEBHOOK_URL"
+          done

--- a/.github/workflows/maintainer_gate.yml
+++ b/.github/workflows/maintainer_gate.yml
@@ -1,0 +1,53 @@
+name: Maintainer gate
+
+# Closes changelog issues filed by non-maintainers. Required ask from review:
+# "restrict TO maintainers ONLY to create these". GitHub has no native persistent
+# setting for this on public repos — action-based gate is the only durable answer.
+# Race: issue is publicly visible ~10-30s before this fires. Accepted tradeoff.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  gate:
+    if: contains(github.event.issue.labels.*.name, 'changelog-entry')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author association
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR']
+            const assoc = context.payload.issue.author_association
+            const ok = allowed.includes(assoc)
+            core.setOutput('ok', ok ? 'true' : 'false')
+            core.setOutput('assoc', assoc)
+            core.info(`author_association=${assoc} ok=${ok}`)
+
+      - name: Reject non-maintainer
+        if: steps.check.outputs.ok != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            }
+            await github.rest.issues.createComment({
+              ...ref,
+              body: [
+                `Thanks for the interest! This issue template is reserved for repo maintainers.`,
+                ``,
+                `If you spotted a bug or have a question, please use [discussions](https://github.com/${context.repo.owner}/${context.repo.repo}/discussions) or contact the team directly.`,
+                ``,
+                `_Auto-closed: \`author_association=${{ steps.check.outputs.assoc }}\`_`,
+              ].join('\n'),
+            })
+            await github.rest.issues.update({ ...ref, state: 'closed', state_reason: 'not_planned' })
+            await github.rest.issues.lock({ ...ref, lock_reason: 'off-topic' })

--- a/.github/workflows/render_changelog.yml
+++ b/.github/workflows/render_changelog.yml
@@ -1,0 +1,115 @@
+name: Render changelog.md
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "changelog/**.yaml"
+      - ".github/workflows/render_changelog.yml"
+      - ".github/schemas/changelog-entry.schema.json"
+  pull_request:
+    paths:
+      - "changelog/**.yaml"
+      - ".github/workflows/render_changelog.yml"
+      - ".github/schemas/changelog-entry.schema.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  validate-and-render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate YAML schema (ajv)
+        run: |
+          npm install --no-save ajv@8 ajv-cli@5 ajv-formats@2
+          for f in changelog/*.yaml; do
+            [ -f "$f" ] || continue
+            npx ajv-cli validate \
+              -s .github/schemas/changelog-entry.schema.json \
+              -d "$f" \
+              -c ajv-formats || exit 1
+          done
+
+      - name: Build releases JSON (with filename)
+        run: |
+          echo '[' > all.json
+          first=true
+          for f in changelog/*.yaml; do
+            [ -f "$f" ] || continue
+            $first || echo ',' >> all.json
+            first=false
+            fname=$(basename "$f" .yaml)
+            yq -o json ". + {\"_filename\": \"$fname\"}" "$f" >> all.json
+          done
+          echo ']' >> all.json
+
+      - name: Validate filename matches inner version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const releases = JSON.parse(fs.readFileSync('all.json', 'utf8'))
+            const mismatches = releases.filter(r => r._filename !== r.version)
+            if (mismatches.length) {
+              for (const r of mismatches) {
+                core.error(`filename ${r._filename}.yaml does not match inner version: ${r.version}`)
+              }
+              core.setFailed(`${mismatches.length} file(s) with filename/version mismatch — rename file or fix version field`)
+            }
+
+      - name: Install semver
+        if: github.event_name == 'push'
+        run: npm install --no-save semver@7
+
+      - name: Render changelog.md
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const semver = require('semver')
+            const releases = JSON.parse(fs.readFileSync('all.json', 'utf8'))
+
+            // Pre-release-aware sort. semver.rcompare handles 1.64.2 > 1.64.2-rc1 etc.
+            releases.sort((a, b) => semver.rcompare(a.version, b.version))
+
+            const TYPE_EMOJI = {
+              new: '🚀New',
+              fix: '🐞Fix',
+              security: '🚨Security Fix',
+              warning: '⚠️Warning',
+              enhancement: '🧐Enhancement',
+            }
+            // `components_raw` (optional) preserves original separator/order for migrated entries
+            // — required for hash parity with ror-api's stored LLM descriptions. New form-driven
+            // entries omit it; renderer falls back to canonical `ES|KBN` join.
+            const compStr = (e) => e.components_raw || e.components.map(c => c.toUpperCase()).join('|')
+
+            let md = '# Changelog\n\n'
+            md += '<!-- AUTO-GENERATED from changelog/*.yaml — do not edit directly -->\n\n'
+            for (const r of releases) {
+              md += `### (${r.release_date}) What's new in **ROR ${r.version}**\n`
+              for (const e of r.entries) {
+                const label = TYPE_EMOJI[e.type] || e.type
+                md += `* **${label}** (${compStr(e)}) ${e.text}\n`
+              }
+              md += '\n'
+            }
+            fs.writeFileSync('changelog.md', md)
+
+      - name: Commit if changed
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add changelog.md
+          if git diff --cached --quiet; then
+            echo "no change"
+          else
+            git commit -m "regen changelog.md from YAMLs"
+            git push
+          fi

--- a/changelog.md
+++ b/changelog.md
@@ -1,108 +1,108 @@
 # Changelog
 
-### (2026-04-10) What’s new in **ROR 1.69.1**
-* **🚨 Security Fix** (KBN) Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)
-* **🚀 New** (KBN) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
-* **🚀 New** (ES) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
-* **🚀 New** (ECK) 3.4.0 support
-* **🐞 Fix** (KBN) Fixed `jsonwebtoken-ancient` being stripped from Kibana builds earlier than 7.11.0
-* **🐞 Fix** (KBN) Filtered out Fleet-based apps from search results when Management is hidden in Kibana 8.x and 9.x
-* **🐞 Fix** (KBN) Fixed `/pkp/session-probe` requests being blocked by browsers that enforce async-only calls
-* **🐞 Fix** (KBN) Fixed a problem with redirecting to the login form after a 401 error following a session probe check
-* **🐞 Fix** (ES) Fixed a missing Kibana access policy in the metadata response when the matched ACL block has no `kibana` section configured
+<!-- AUTO-GENERATED from changelog/*.yaml — do not edit directly -->
 
-### (2026-04-02) What’s new in **ROR 1.69.0**
-* **🚨 Security Fix** (KBN) [CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), [CVE-2025-69873](https://nvd.nist.gov/vuln/detail/CVE-2025-69873), [CVE-2026-2391](https://nvd.nist.gov/vuln/detail/CVE-2026-2391), [CVE-2026-25639](https://nvd.nist.gov/vuln/detail/CVE-2026-25639), [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904), [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449), [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599), [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750), [CVE-2026-4867](https://nvd.nist.gov/vuln/detail/CVE-2026-4867), [CVE-2026-34601](https://www.tenable.com/cve/CVE-2026-34601), [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/cve-2022-31129)
-* **🚀 New** (KBN/ES) [Added Fleet support via native API key and service account token authentication (ES 7.14+)](https://docs.readonlyrest.com/elasticsearch/fleet)
-* **🚀 New** (KBN/ES) The ReadonlyREST Audit Dashboard available in the Kibana plugin now supports audit events written to data streams
-* **🚀 New** (KBN/ES) The ReadonlyREST Audit Dashboard provided by the Kibana plugin can now be used with the ECS (Elastic Common Schema) audit index
-* **🚀 New** (KBN) [Added support for opening different tenancies in separate tabs](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)
-* **🚀 New** (KBN) [Added support for sharing links to Kibana visualizations for the selected tenancy](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)
-* **🚀 New** (KBN) Added support for rolling upgrades when upgrading the ROR Elasticsearch plugin and ROR Kibana plugin in a cluster
-* **🧐 Enhancement** (KBN) Removed the need for manual username input in the impersonation mechanism
-* **🧐 Enhancement** (KBN) Fixed an error in Kibana caused by empty data streams in Kibana 8.18.0+
-* **🧐 Enhancement** (KBN) Added a fallback for an empty `indices` field in the Audit Dashboard
-* **🧐 Enhancement** (KBN) [Updated custom metadata examples to use the new method. `getIdentitySession` and `getAuthorizationHeaders` are now deprecated in favor of `getUserRequestIdentity`, `getIdentitySessionHeaders`, and `getWhitelistedHeaders`](https://docs.readonlyrest.com/develop/examples/custom-middleware)
-* **🧐 Enhancement** (ES) [`token_authentication` rule extended with `api_key` and `service_token` types](https://docs.readonlyrest.com/elasticsearch#token_authentication)
-* **🧐 Enhancement** (ES) [Audit log entries and ACL history now include a human-readable reason when a request is denied, making access-control troubleshooting significantly easier](https://forum.readonlyrest.com/t/distinguish-between-wrong-credentials-and-missing-permissions/2914)
-* **🧐 Enhancement** (ES) Added the new `matched_block_names` field to audit entries created by audit log serializers other than ECS and custom serializers. The `reason` field is now deprecated.
-* **🧐 Enhancement** (ES) Users defined with LDAP, external, and `ror_kbn` authentication are no longer treated as local users by the impersonation mechanism
-* **🧐 Enhancement** (ES) The ROR Kibana plugin can no longer be used when the `prompt_for_basic_auth: true` setting is configured
-* **🐞 Fix** (KBN) Resolved a memory leak related to direct calls via the Kibana API
-* **🐞 Fix** (KBN) No longer shows the "Data Set Quality" and "Index management" applications to users with RO or RO_strict access
-* **🐞 Fix** (KBN) Fixed JWT token authorization when using embedded Kibana
-* **🐞 Fix** (KBN) Fixed the styling of the page-not-found screen for Kibana 9.x
-* **🐞 Fix** (KBN) Correctly displays the "Who uses what indices?" Audit Dashboard visualization when indices are not specified in the audit events
-* **🐞 Fix** (ES) [Improved stability when sending audit logs to another cluster, so temporary remote cluster outages no longer affect the main cluster](https://forum.readonlyrest.com/t/sending-logs-to-another-cluster/2925)
-* **🐞 Fix** (ES) Fixed Search Profiler being inactive in Kibana 8.18.0+
-* **🐞 Fix** (ES) `beshultd/elasticsearch-readonlyrest` images for ES 7.16.x, 7.17.0–7.17.6, and 8.0.x–8.4.x now ship with a patched JDK, replacing bundled JDK 17.0.0–17.0.4 / JDK 18, which crashes on cgroup v2 hosts due to JDK-8287073
+### (2026-04-10) What's new in **ROR 1.69.1**
+* **🚨Security Fix** (KBN) Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)
+* **🚀New** (KBN) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
+* **🚀New** (ES) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
+* **🚀New** (ECK) 3.4.0 support
+* **🐞Fix** (KBN) Fixed `jsonwebtoken-ancient` being stripped from Kibana builds earlier than 7.11.0
+* **🐞Fix** (KBN) Filtered out Fleet-based apps from search results when Management is hidden in Kibana 8.x and 9.x
+* **🐞Fix** (KBN) Fixed `/pkp/session-probe` requests being blocked by browsers that enforce async-only calls
+* **🐞Fix** (KBN) Fixed a problem with redirecting to the login form after a 401 error following a session probe check
+* **🐞Fix** (ES) Fixed a missing Kibana access policy in the metadata response when the matched ACL block has no `kibana` section configured
 
+### (2026-04-02) What's new in **ROR 1.69.0**
+* **🚨Security Fix** (KBN) [CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), [CVE-2025-69873](https://nvd.nist.gov/vuln/detail/CVE-2025-69873), [CVE-2026-2391](https://nvd.nist.gov/vuln/detail/CVE-2026-2391), [CVE-2026-25639](https://nvd.nist.gov/vuln/detail/CVE-2026-25639), [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904), [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449), [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599), [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750), [CVE-2026-4867](https://nvd.nist.gov/vuln/detail/CVE-2026-4867), [CVE-2026-34601](https://www.tenable.com/cve/CVE-2026-34601), [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/cve-2022-31129)
+* **🚀New** (KBN/ES) [Added Fleet support via native API key and service account token authentication (ES 7.14+)](https://docs.readonlyrest.com/elasticsearch/fleet)
+* **🚀New** (KBN/ES) The ReadonlyREST Audit Dashboard available in the Kibana plugin now supports audit events written to data streams
+* **🚀New** (KBN/ES) The ReadonlyREST Audit Dashboard provided by the Kibana plugin can now be used with the ECS (Elastic Common Schema) audit index
+* **🚀New** (KBN) [Added support for opening different tenancies in separate tabs](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)
+* **🚀New** (KBN) [Added support for sharing links to Kibana visualizations for the selected tenancy](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)
+* **🚀New** (KBN) Added support for rolling upgrades when upgrading the ROR Elasticsearch plugin and ROR Kibana plugin in a cluster
+* **🧐Enhancement** (KBN) Removed the need for manual username input in the impersonation mechanism
+* **🧐Enhancement** (KBN) Fixed an error in Kibana caused by empty data streams in Kibana 8.18.0+
+* **🧐Enhancement** (KBN) Added a fallback for an empty `indices` field in the Audit Dashboard
+* **🧐Enhancement** (KBN) [Updated custom metadata examples to use the new method. `getIdentitySession` and `getAuthorizationHeaders` are now deprecated in favor of `getUserRequestIdentity`, `getIdentitySessionHeaders`, and `getWhitelistedHeaders`](https://docs.readonlyrest.com/develop/examples/custom-middleware)
+* **🧐Enhancement** (ES) [`token_authentication` rule extended with `api_key` and `service_token` types](https://docs.readonlyrest.com/elasticsearch#token_authentication)
+* **🧐Enhancement** (ES) [Audit log entries and ACL history now include a human-readable reason when a request is denied, making access-control troubleshooting significantly easier](https://forum.readonlyrest.com/t/distinguish-between-wrong-credentials-and-missing-permissions/2914)
+* **🧐Enhancement** (ES) Added the new `matched_block_names` field to audit entries created by audit log serializers other than ECS and custom serializers. The `reason` field is now deprecated.
+* **🧐Enhancement** (ES) Users defined with LDAP, external, and `ror_kbn` authentication are no longer treated as local users by the impersonation mechanism
+* **🧐Enhancement** (ES) The ROR Kibana plugin can no longer be used when the `prompt_for_basic_auth: true` setting is configured
+* **🐞Fix** (KBN) Resolved a memory leak related to direct calls via the Kibana API
+* **🐞Fix** (KBN) No longer shows the "Data Set Quality" and "Index management" applications to users with RO or RO_strict access
+* **🐞Fix** (KBN) Fixed JWT token authorization when using embedded Kibana
+* **🐞Fix** (KBN) Fixed the styling of the page-not-found screen for Kibana 9.x
+* **🐞Fix** (KBN) Correctly displays the "Who uses what indices?" Audit Dashboard visualization when indices are not specified in the audit events
+* **🐞Fix** (ES) [Improved stability when sending audit logs to another cluster, so temporary remote cluster outages no longer affect the main cluster](https://forum.readonlyrest.com/t/sending-logs-to-another-cluster/2925)
+* **🐞Fix** (ES) Fixed Search Profiler being inactive in Kibana 8.18.0+
+* **🐞Fix** (ES) `beshultd/elasticsearch-readonlyrest` images for ES 7.16.x, 7.17.0–7.17.6, and 8.0.x–8.4.x now ship with a patched JDK, replacing bundled JDK 17.0.0–17.0.4 / JDK 18, which crashes on cgroup v2 hosts due to JDK-8287073
 
-### (2026-01-07) What’s new in **ROR 1.68.0**
-* **🚨 Security Fix** (KBN) [CVE-2024-51999](https://nvd.nist.gov/vuln/detail/CVE-2024-51999), [CVE-2025-65945](https://nvd.nist.gov/vuln/detail/CVE-2025-65945)
-* **🚨 Security Fix** (ES) [CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735), [CVE-2025-66453](https://nvd.nist.gov/vuln/detail/CVE-2025-66453)
-* **⚠️Warning** (ES) Audit outputs now use the round-robin strategy for custom audit clusters. [Audit nodes must belong to the same Elasticsearch cluster; otherwise, audit events may be incomplete](https://docs.readonlyrest.com/elasticsearch/audit#custom-audit-cluster)
- for configuration guidelines.
-* **🚀 New** (KBN) 9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support
-* **🚀 New** (ES) 9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support
-* **🚀 New** (KBN) Added "Remember last picked tenant" feature for external identity providers
-* **🚀 New** (KBN) Introduced support for the Kibana Data Set Quality beta application
-* **🚀 New** (KBN) Restyled ROR menu featuring searchable tenancy selector
-* **🚀 New** (ES) Added new rules: [`jwt_authentication`](https://docs.readonlyrest.com/elasticsearch#jwt_authentication) and [`jwt_authorization`](https://docs.readonlyrest.com/elasticsearch#jwt_authorization), as alternatives to the existing `jwt_auth` rule
-* **🚀 New** (ES) [New audit log serializer compliant with Elastic Common Schema (ECS)](https://docs.readonlyrest.com/elasticsearch/audit#using-ecs-serializer)
-* **🚀 New** (ES) [The audit can be enabled or disabled on the block level](https://docs.readonlyrest.com/elasticsearch/audit#configuration)
-* **🧐 Enhancement** (KBN) Disabled caching in the Login CSRF protection mechanism.
-* **🧐 Enhancement** (KBN) Made the tenant indicator always visible and improved its dropdown behavior
-* **🧐 Enhancement** (KBN) Added stack traces to ReadonlyREST KBN plugin error logs for easier debugging
-* **🧐 Enhancement** (ES) [Added LDAP connection health checking to prevent stale connection authentication failures](https://forum.readonlyrest.com/t/ldap-connection-timeout-leads-to-authentication-error/2899)
-* **🧐 Enhancement** (ES) [Enable nested field definitions in the configurable audit log serializer for more flexible audit logging](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)
-* **🧐 Enhancement** (ES) [The predefined audit log serializers](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers) now include a new `logged_user` field, which contains a human-readable username
-* **🐞 Fix** (KBN) Resolved an issue causing the Kibana Search Sessions app to fail on Kibana 8.x
-* **🐞 Fix** (ES) [Fixed cluster resolution issues that caused Kibana errors and unexpected logouts in versions 8.19.x and above](https://forum.readonlyrest.com/t/errors-after-upgrade-kibana-7-17-29-to-8-19-7/2887)
+### (2026-01-07) What's new in **ROR 1.68.0**
+* **🚨Security Fix** (KBN) [CVE-2024-51999](https://nvd.nist.gov/vuln/detail/CVE-2024-51999), [CVE-2025-65945](https://nvd.nist.gov/vuln/detail/CVE-2025-65945)
+* **🚨Security Fix** (ES) [CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735), [CVE-2025-66453](https://nvd.nist.gov/vuln/detail/CVE-2025-66453)
+* **⚠️Warning** (ES) Audit outputs now use the round-robin strategy for custom audit clusters. [Audit nodes must belong to the same Elasticsearch cluster; otherwise, audit events may be incomplete](https://docs.readonlyrest.com/elasticsearch/audit#custom-audit-cluster)  for configuration guidelines.
+* **🚀New** (KBN) 9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support
+* **🚀New** (ES) 9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support
+* **🚀New** (KBN) Added "Remember last picked tenant" feature for external identity providers
+* **🚀New** (KBN) Introduced support for the Kibana Data Set Quality beta application
+* **🚀New** (KBN) Restyled ROR menu featuring searchable tenancy selector
+* **🚀New** (ES) Added new rules: [`jwt_authentication`](https://docs.readonlyrest.com/elasticsearch#jwt_authentication) and [`jwt_authorization`](https://docs.readonlyrest.com/elasticsearch#jwt_authorization), as alternatives to the existing `jwt_auth` rule
+* **🚀New** (ES) [New audit log serializer compliant with Elastic Common Schema (ECS)](https://docs.readonlyrest.com/elasticsearch/audit#using-ecs-serializer)
+* **🚀New** (ES) [The audit can be enabled or disabled on the block level](https://docs.readonlyrest.com/elasticsearch/audit#configuration)
+* **🧐Enhancement** (KBN) Disabled caching in the Login CSRF protection mechanism.
+* **🧐Enhancement** (KBN) Made the tenant indicator always visible and improved its dropdown behavior
+* **🧐Enhancement** (KBN) Added stack traces to ReadonlyREST KBN plugin error logs for easier debugging
+* **🧐Enhancement** (ES) [Added LDAP connection health checking to prevent stale connection authentication failures](https://forum.readonlyrest.com/t/ldap-connection-timeout-leads-to-authentication-error/2899)
+* **🧐Enhancement** (ES) [Enable nested field definitions in the configurable audit log serializer for more flexible audit logging](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)
+* **🧐Enhancement** (ES) [The predefined audit log serializers](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers) now include a new `logged_user` field, which contains a human-readable username
+* **🐞Fix** (KBN) Resolved an issue causing the Kibana Search Sessions app to fail on Kibana 8.x
+* **🐞Fix** (ES) [Fixed cluster resolution issues that caused Kibana errors and unexpected logouts in versions 8.19.x and above](https://forum.readonlyrest.com/t/errors-after-upgrade-kibana-7-17-29-to-8-19-7/2887)
 
-### (2025-11-29) What’s new in **ROR 1.67.3**
-* **🚀 New** (KBN) 9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support
-* **🚀 New** (ES) 9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support
-* **🐞 Fix** (ES) Resolved index resolution compatibility issue with Elasticsearch 9.1.7
+### (2025-11-29) What's new in **ROR 1.67.3**
+* **🚀New** (KBN) 9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support
+* **🚀New** (ES) 9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support
+* **🐞Fix** (ES) Resolved index resolution compatibility issue with Elasticsearch 9.1.7
 
-### (2025-11-13) What’s new in **ROR 1.67.2**
-* **🚀 New** (KBN) 9.2.1, 9.1.7, 8.19.7 support
-* **🚀 New** (ES) 9.2.1, 9.1.7, 8.19.7 support
-* **🐞 Fix** (KBN) Fixed SAML/OIDC provider support behind a reverse proxy when `server.rewriteBasePath: false` is set in kibana.yml
-* **🐞 Fix** (ES) Delegated handling of certain internal exceptions to Elasticsearch, preserving native error responses
+### (2025-11-13) What's new in **ROR 1.67.2**
+* **🚀New** (KBN) 9.2.1, 9.1.7, 8.19.7 support
+* **🚀New** (ES) 9.2.1, 9.1.7, 8.19.7 support
+* **🐞Fix** (KBN) Fixed SAML/OIDC provider support behind a reverse proxy when `server.rewriteBasePath: false` is set in kibana.yml
+* **🐞Fix** (ES) Delegated handling of certain internal exceptions to Elasticsearch, preserving native error responses
 
-### (2025-11-03) What’s new in **ROR 1.67.1**
-* **🚀 New** (KBN) 9.2.0, 9.1.6, 8.19.6 support
-* **🚀 New** (ES) 9.2.0, 9.1.6, 8.19.6 support
-* **🧐 Enhancement** (ES) Allow using the `actions` rule with the `kibana` rule in the same block when `kibana.access: unrestricted`
-* **🐞 Fix** (KBN) Fixed JWT handling for wrong license edition
-* **🐞 Fix** (KBN) Suppressed “Forbidden” toast in Discover/Dashboard on Kibana 8.x–9.x
-* **🐞 Fix** (KBN) [Resolved report download failure on Kibana 9.1.x](https://forum.readonlyrest.com/t/unable-to-download-reports-from-kibana/2859/2)
-* **🐞 Fix** (KBN) Fixed timeout when saving Security settings
-* **🐞 Fix** (KBN) Restored visibility of reports when multiple data streams exist for a reporting index
-* **🐞 Fix** (KBN) Fixed invisible reports for non-tenancy users on Kibana 9.1.x
+### (2025-11-03) What's new in **ROR 1.67.1**
+* **🚀New** (KBN) 9.2.0, 9.1.6, 8.19.6 support
+* **🚀New** (ES) 9.2.0, 9.1.6, 8.19.6 support
+* **🧐Enhancement** (ES) Allow using the `actions` rule with the `kibana` rule in the same block when `kibana.access: unrestricted`
+* **🐞Fix** (KBN) Fixed JWT handling for wrong license edition
+* **🐞Fix** (KBN) Suppressed “Forbidden” toast in Discover/Dashboard on Kibana 8.x–9.x
+* **🐞Fix** (KBN) [Resolved report download failure on Kibana 9.1.x](https://forum.readonlyrest.com/t/unable-to-download-reports-from-kibana/2859/2)
+* **🐞Fix** (KBN) Fixed timeout when saving Security settings
+* **🐞Fix** (KBN) Restored visibility of reports when multiple data streams exist for a reporting index
+* **🐞Fix** (KBN) Fixed invisible reports for non-tenancy users on Kibana 9.1.x
 
-### (2025-10-14) What’s new in **ROR 1.67.0**
-* **🚨 Security Fix** (KBN) [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)
-* **🚨 Security Fix** (ES) [CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057), [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)
-* **🚀 New** (ES) [Added support for defining a custom audit serializer directly in ROR settings (no code required)](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)
-* **🚀 New** (ES) [Introduced new predefined audit serializers: `ReportingAllEventsAuditLogSerializer`, `ReportingAllEventsWithQueryAuditLogSerializer`](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers)
-* **🚀 New** (ES) Added new rules: [`ror_kbn_authentication`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authentication) and [`ror_kbn_authorization`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authorization), as alternatives to the existing `ror_kbn_auth` rule
-* **🧐 Enhancement** (KBN) [Added OIDC `clock-skew-tolerance` configuration option in `kibana.yml`](https://docs.readonlyrest.com/kibana#clock-skew-tolerance)
-* **🧐 Enhancement** (KBN) [Added option to disable Kibana termination on watermark errors in `kibana.yml`](https://docs.readonlyrest.com/kibana#terminate-kibana-on-es-high-watermark)
-* **🐞 Fix** (KBN) Logout did not invalidate the app session when the `ror_kbn_auth` rule was used with local group definitions
-* **🐞 Fix** (KBN) [Restored keyword field value suggestions in Discover/Data View filters](https://forum.readonlyrest.com/t/kibana-data-view-filter-not-working-with-keyword/2843)
-* **🐞 Fix** (KBN) Integration-based options were visible in search results even when the app was marked as hidden
-* **🐞 Fix** (KBN) Index Management appeared in app search results even when the app was declared as hidden
-* **🐞 Fix** (KBN) Resolved an issue with CSRF token override when multiple browser tabs were open
-* **🐞 Fix** (KBN) Fixed OIDC compatibility for Kibana 7.10.2 and earlier
-* **🐞 Fix** (ES) Restored backward compatibility for custom audit log serializer implementations extending the `DefaultAuditLogSerializer` class. Custom serializers compiled against ROR 1.65 or 1.66 that use `DefaultAuditLogSerializer` must be recompiled to work correctly
-* **🐞 Fix** (ES) Fixed a defect that broke the "Snapshot and Restore" functionality in Kibana
+### (2025-10-14) What's new in **ROR 1.67.0**
+* **🚨Security Fix** (KBN) [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)
+* **🚨Security Fix** (ES) [CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057), [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)
+* **🚀New** (ES) [Added support for defining a custom audit serializer directly in ROR settings (no code required)](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)
+* **🚀New** (ES) [Introduced new predefined audit serializers: `ReportingAllEventsAuditLogSerializer`, `ReportingAllEventsWithQueryAuditLogSerializer`](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers)
+* **🚀New** (ES) Added new rules: [`ror_kbn_authentication`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authentication) and [`ror_kbn_authorization`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authorization), as alternatives to the existing `ror_kbn_auth` rule
+* **🧐Enhancement** (KBN) [Added OIDC `clock-skew-tolerance` configuration option in `kibana.yml`](https://docs.readonlyrest.com/kibana#clock-skew-tolerance)
+* **🧐Enhancement** (KBN) [Added option to disable Kibana termination on watermark errors in `kibana.yml`](https://docs.readonlyrest.com/kibana#terminate-kibana-on-es-high-watermark)
+* **🐞Fix** (KBN) Logout did not invalidate the app session when the `ror_kbn_auth` rule was used with local group definitions
+* **🐞Fix** (KBN) [Restored keyword field value suggestions in Discover/Data View filters](https://forum.readonlyrest.com/t/kibana-data-view-filter-not-working-with-keyword/2843)
+* **🐞Fix** (KBN) Integration-based options were visible in search results even when the app was marked as hidden
+* **🐞Fix** (KBN) Index Management appeared in app search results even when the app was declared as hidden
+* **🐞Fix** (KBN) Resolved an issue with CSRF token override when multiple browser tabs were open
+* **🐞Fix** (KBN) Fixed OIDC compatibility for Kibana 7.10.2 and earlier
+* **🐞Fix** (ES) Restored backward compatibility for custom audit log serializer implementations extending the `DefaultAuditLogSerializer` class. Custom serializers compiled against ROR 1.65 or 1.66 that use `DefaultAuditLogSerializer` must be recompiled to work correctly
+* **🐞Fix** (ES) Fixed a defect that broke the "Snapshot and Restore" functionality in Kibana
 
 ### (2025-09-03) What's new in **ROR 1.66.1**
-* **🚀 New** (KBN) 9.1.5, 9.1.4, 9.0.8, 9.0.7 8.19.5, 8.19.4, 8.18.7 support
-* **🚀 New** (ES) 9.1.5, 9.1.4, 9.0.8, 9.0.7, 8.19.5, 8.19.4, 8.18.8, 8.18.7 support
-* **🐞 Fix** (ES) [Patching issue in Elasticsearch 9.x, 8.19.x, and 8.18.x that caused startup failures on Java 17](https://forum.readonlyrest.com/t/ror-1-65-1-java-17/2841)
+* **🚀New** (KBN) 9.1.5, 9.1.4, 9.0.8, 9.0.7 8.19.5, 8.19.4, 8.18.7 support
+* **🚀New** (ES) 9.1.5, 9.1.4, 9.0.8, 9.0.7, 8.19.5, 8.19.4, 8.18.8, 8.18.7 support
+* **🐞Fix** (ES) [Patching issue in Elasticsearch 9.x, 8.19.x, and 8.18.x that caused startup failures on Java 17](https://forum.readonlyrest.com/t/ror-1-65-1-java-17/2841)
 
 ### (2025-08-28) What's new in **ROR 1.66.0**
 * **🚨Security Fix** (KBN) [CVE-2025-7339](https://nvd.nist.gov/vuln/detail/CVE-2025-7339), [CVE-2025-7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783), [CVE-2025-54419](https://nvd.nist.gov/vuln/detail/CVE-2025-54419), [CVE-2025-9288](https://nvd.nist.gov/vuln/detail/CVE-2025-9288)
@@ -122,13 +122,13 @@
 ### (2025-07-15) What's new in **ROR 1.65.1**
 * **🚀New** (KBN) 9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support
 * **🚀New** (ES) 9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support
-* **🚀New** (ECK) 3.1.0 support 
+* **🚀New** (ECK) 3.1.0 support
 * **🐞Fix** (ES) Docker images now start correctly when `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING` is set.
 
 ### (2025-07-10) What's new in **ROR 1.65.0**
 * **🚨Security Fix** (KBN) [CVE-2025-5889](https://nvd.nist.gov/vuln/detail/CVE-2025-5889)
 * **🚨Security Fix** (ES) [CVE-2024-29857](https://nvd.nist.gov/vuln/detail/cve-2024-29857) (when FIPS SSL is used)
-* **🚀New** (KBN)  Added support for configuring [JSON log format](https://www.elastic.co/docs/troubleshoot/kibana/using-kibana-server-logs) in `kibana.yml`.
+* **🚀New** (KBN) Added support for configuring [JSON log format](https://www.elastic.co/docs/troubleshoot/kibana/using-kibana-server-logs) in `kibana.yml`.
 * **🚀New** (ES) [Added support for a new output type: `data_stream` in audit logging](https://docs.readonlyrest.com/elasticsearch/audit#configuration).
 * **🚀New** (ES) Included Elasticsearch node name and cluster name in the audit reports.
 * **🧐Enhancement** (KBN) Logged detailed messages when the CSRF token has expired.
@@ -144,43 +144,29 @@
 * **🐞Fix** (ES) File ownership and permissions are now preserved during `ror-tools` patch and unpatch operations.
 
 ### (2025-05-17) What's new in **ROR 1.64.2**
-* **🚀New** (KBN) 9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support 
-* **🚀New** (ES) 9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support 
+* **🚀New** (KBN) 9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support
+* **🚀New** (ES) 9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support
 * **🐞Fix** (ES) [Fixed an issue with Elasticsearch patching process on Windows operating systems](https://forum.readonlyrest.com/t/ror-1-64-0-for-es9-0-1-windows-setup/2778)
 
 ### (2025-05-13) What's new in **ROR 1.64.1**
 * **🐞Fix** (ES) Correct patching verification in ROR Docker image entrypoint
 
 ### (2025-05-11) What's new in **ROR 1.64.0**
-* **🚨Security Fix** (KBN)  
-[CVE-2024-53382](https://nvd.nist.gov/vuln/detail/CVE-2024-53382), [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789), [CVE-2025-29774](https://www.cve.org/CVERecord?id=CVE-2025-29774)
-* **🚨Security Fix** (ES) [CVE-2023-3894](https://nvd.nist.gov/vuln/detail/CVE-2023-3894),
-[CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193)
+* **🚨Security Fix** (KBN) [CVE-2024-53382](https://nvd.nist.gov/vuln/detail/CVE-2024-53382), [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789), [CVE-2025-29774](https://www.cve.org/CVERecord?id=CVE-2025-29774)
+* **🚨Security Fix** (ES) [CVE-2023-3894](https://nvd.nist.gov/vuln/detail/CVE-2023-3894), [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193)
 * **⚠️Warning** (ES) Acknowledgement needs to be accepted before the Elasticsearch patching process. For scripts, you can [set the flag](https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch) to automate the process.
-* **🚀New** (KBN)  
-Added an endpoint to retrieve all user tenancies via the ReadonlyREST API. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/User's%20tenants/get_api_ror_user_tenants) for usage details.
-* **🚀New** (KBN)  
-Introduced support for passing `x-ror-tenancy-id` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details.
-* **🚀New** (KBN)  
-Introduced support for passing `x-ror-impersonating` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details.
-* **🧐Enhancement** (KBN)  
-Retains the currently selected group information after user logout. This setting is user-configurable and disabled by default.
-* **🧐Enhancement** (KBN)  
-Displays [detailed "reason" messages from the ROR Elasticsearch](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration) response in the login form instead of a generic "Wrong credentials" message.
-* **🧐Enhancement** (KBN)  
-Added support for passing additional [SAML](https://docs.readonlyrest.com/kibana#additional-parameters) and [OIDC](https://docs.readonlyrest.com/kibana#additional-parameters) config parameters via `kibana.yml`.
-* **🧐Enhancement** (KBN)  
-Adjusted ReadonlyREST plugin UI styles for compatibility with Kibana 9.x.
-* **🧐Enhancement** (ES)  
-Username duplication check in the "users" section of ROR ES settings can [be optionally disabled](https://docs.readonlyrest.com/elasticsearch#users_section_duplicate_usernames_detection).
-* **🧐Enhancement** (ES)  
-Added support for [`readonlyrest.global_settings`](https://docs.readonlyrest.com/elasticsearch#global-settings) in Elasticsearch ROR settings.
-* **🐞Fix** (KBN)  
-Resolved an unhandled error when `logging.root.level` is set to `all` in `kibana.yml`.
-* **🐞Fix** (KBN)  
-Fixed an issue with retrieving username and group information in AFDS OIDC.
-* **🐞Fix** (KBN)  
-Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API request.
+* **🚀New** (KBN) Added an endpoint to retrieve all user tenancies via the ReadonlyREST API. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/User's%20tenants/get_api_ror_user_tenants) for usage details.
+* **🚀New** (KBN) Introduced support for passing `x-ror-tenancy-id` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details.
+* **🚀New** (KBN) Introduced support for passing `x-ror-impersonating` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details.
+* **🧐Enhancement** (KBN) Retains the currently selected group information after user logout. This setting is user-configurable and disabled by default.
+* **🧐Enhancement** (KBN) Displays [detailed "reason" messages from the ROR Elasticsearch](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration) response in the login form instead of a generic "Wrong credentials" message.
+* **🧐Enhancement** (KBN) Added support for passing additional [SAML](https://docs.readonlyrest.com/kibana#additional-parameters) and [OIDC](https://docs.readonlyrest.com/kibana#additional-parameters) config parameters via `kibana.yml`.
+* **🧐Enhancement** (KBN) Adjusted ReadonlyREST plugin UI styles for compatibility with Kibana 9.x.
+* **🧐Enhancement** (ES) Username duplication check in the "users" section of ROR ES settings can [be optionally disabled](https://docs.readonlyrest.com/elasticsearch#users_section_duplicate_usernames_detection).
+* **🧐Enhancement** (ES) Added support for [`readonlyrest.global_settings`](https://docs.readonlyrest.com/elasticsearch#global-settings) in Elasticsearch ROR settings.
+* **🐞Fix** (KBN) Resolved an unhandled error when `logging.root.level` is set to `all` in `kibana.yml`.
+* **🐞Fix** (KBN) Fixed an issue with retrieving username and group information in AFDS OIDC.
+* **🐞Fix** (KBN) Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API request.
 
 ### (2025-03-12) What's new in **ROR 1.63.0**
 * **🚨Security Fix** (KBN) [CVE-2025-26791](https://www.cve.org/CVERecord?id=CVE-2025-26791), [CWE-772](https://cwe.mitre.org/data/definitions/772.html)
@@ -224,12 +210,12 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚨Security Fix** (ES) [CVE-2024-47535](https://nvd.nist.gov/vuln/detail/CVE-2024-47535)
 * **🚀New** (KBN) 8.17.0, 8.16.2, 8.16.1, 8.16.0, 8.15.5, 7.17.27, 7.17.26 support
 * **🚀New** (ES) 8.17.0, 8.16.2, 8.16.1, 8.15.5, 7.17.27, 7.17.26 support
-* **🚀New** (ES) ESQL support 
+* **🚀New** (ES) ESQL support
 * **🐞Fix** (KBN) Elasticsearch red status shouldn't kill the Kibana process on initialization
 
 ### (2024-11-12) What's new in **ROR 1.61.0**
 * **🚨Security Fix** (KBN) [CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764)
-* **⚠️Warning** (KBN) Acknowledgement needs to be accepted before a Kibana patching process. For scripts, you can [set a flag](https://docs.readonlyrest.com/kibana#patching-kibana) to automate a process (edited) 
+* **⚠️Warning** (KBN) Acknowledgement needs to be accepted before a Kibana patching process. For scripts, you can [set a flag](https://docs.readonlyrest.com/kibana#patching-kibana) to automate a process (edited)
 * **🚀New** (KBN) 8.15.4 support
 * **🚀New** (ES) 8.16.0, 8.15.4 support
 * **🚀New** (ES) There is an option to define [a custom response for users in ACL block with the 'forbid' policy](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration)
@@ -253,7 +239,7 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚀New** (KBN|ES) [ECK support documentation](https://docs.readonlyrest.com/eck)
 * **🚀New** (ES) configurable ROR YAML settings max size
 * **⚠️Warning** (ES) The prompt for basic authorization is disabled by default. To keep the previous behavior, set `readonlyrest.prompt_for_basic_auth` to `true` in the ROR configuration
-* **🧐Enhancement** (KBN) There is an option to define [client authentication methods](https://docs.readonlyrest.com/kibana#client-authentication-methods) in the `kibana.yml` via `readonlyrest_kbn.auth.<YOUR_OIDC_CONFIG>.tokenEndpointAuthMethod`, 'client_secret_post' or ''client_secret_basic' 
+* **🧐Enhancement** (KBN) There is an option to define [client authentication methods](https://docs.readonlyrest.com/kibana#client-authentication-methods) in the `kibana.yml` via `readonlyrest_kbn.auth.<YOUR_OIDC_CONFIG>.tokenEndpointAuthMethod`, 'client_secret_post' or ''client_secret_basic'
 * **🧐Enhancement** (KBN) Stop Kibana when enabled features are not available
 * **🐞Fix** (KBN) HTTP 400 (bad request) issue when there is a Nginx proxy server between es and Kibana
 * **🐞Fix** (KBN) Fix for the problem with correctly hiding Management features `ROR Manage Kibana` defined in the readonlyrest.yml `kibana_hide_apps` property
@@ -264,18 +250,18 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 ### (2024-08-01) What's new in **ROR 1.59.0**
 * **🚀New** (ES) 8.15.1, 8.15.0, 7.17.24, 7.17.23, 6.7.x support
 * **🚀New** (KBN) 8.15.1, 8.15.0, 7.17.24, 7.17.23 support
-* **🧐Enhancement** (KBN) Replace a broken Alert and Connectors applications with the link to our [new tool](https://anaphora.it) for Reports and alerting for Kibana > 8.6.0 (edited) 
+* **🧐Enhancement** (KBN) Replace a broken Alert and Connectors applications with the link to our [new tool](https://anaphora.it) for Reports and alerting for Kibana > 8.6.0 (edited)
 * **🐞Fix** (KBN) Handling reporting URL for report generation
 * **🐞Fix** (KBN) Embedding with inline JWT is a feature available only in ReadonlyREST PRO and Enterprise
 * **🐞Fix** (ES) [Patcher `UnsupportedOperationException` issue on Windows](https://forum.readonlyrest.com/t/ror-1-58-0-for-es8-14-3-windows-setup/2577)
 * **🐞Fix** (ES) for the problem with `_async_search` on ES 8.14.x
 
 ### (2024-06-30) What's new in **ROR 1.58.0**
-* **🚨Security Fix**(KBN) [CVE-2022-39353](https://www.cve.org/CVERecord?id=CVE-2022-39353), [CVE-2020-7753](https://www.cve.org/CVERecord?id=CVE-2020-7753), [CVE-2022-37616](https://www.cve.org/CVERecord?id=CVE-2022-37616), [CVE-2024-29041](https://www.cve.org/CVERecord?id=CVE-2024-29041), [CVE-2022-0691](https://www.cve.org/CVERecord?id=CVE-2022-0691), [CVE-2021-3801](https://www.cve.org/CVERecord?id=CVE-2021-3801), [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883), [CVE-2022-0512](https://www.cve.org/CVERecord?id=CVE-2022-0512), [CVE-2022-0686](https://www.cve.org/CVERecord?id=CVE-2022-0686), [CVE-2022-0639](https://www.cve.org/CVERecord?id=CVE-2022-0639), [CVE-2022-25881](https://www.cve.org/CVERecord?id=CVE-2022-25881), [CVE-2023-0842](https://www.cve.org/CVERecord?id=CVE-2023-0842), [CVE-2017-16137](https://www.cve.org/CVERecord?id=CVE-2017-16137), [CVE-2022-33987](https://www.cve.org/CVERecord?id=CVE-2022-33987), [CVE-2022-23647](https://www.cve.org/CVERecord?id=CVE-2022-23647), [CVE-2022-36083](https://www.cve.org/CVERecord?id=CVE-2022-36083), [CVE-2024-28176](https://www.cve.org/CVERecord?id=CVE-2024-28176)
+* **🚨Security Fix** (KBN) [CVE-2022-39353](https://www.cve.org/CVERecord?id=CVE-2022-39353), [CVE-2020-7753](https://www.cve.org/CVERecord?id=CVE-2020-7753), [CVE-2022-37616](https://www.cve.org/CVERecord?id=CVE-2022-37616), [CVE-2024-29041](https://www.cve.org/CVERecord?id=CVE-2024-29041), [CVE-2022-0691](https://www.cve.org/CVERecord?id=CVE-2022-0691), [CVE-2021-3801](https://www.cve.org/CVERecord?id=CVE-2021-3801), [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883), [CVE-2022-0512](https://www.cve.org/CVERecord?id=CVE-2022-0512), [CVE-2022-0686](https://www.cve.org/CVERecord?id=CVE-2022-0686), [CVE-2022-0639](https://www.cve.org/CVERecord?id=CVE-2022-0639), [CVE-2022-25881](https://www.cve.org/CVERecord?id=CVE-2022-25881), [CVE-2023-0842](https://www.cve.org/CVERecord?id=CVE-2023-0842), [CVE-2017-16137](https://www.cve.org/CVERecord?id=CVE-2017-16137), [CVE-2022-33987](https://www.cve.org/CVERecord?id=CVE-2022-33987), [CVE-2022-23647](https://www.cve.org/CVERecord?id=CVE-2022-23647), [CVE-2022-36083](https://www.cve.org/CVERecord?id=CVE-2022-36083), [CVE-2024-28176](https://www.cve.org/CVERecord?id=CVE-2024-28176)
 * **🚀New** (KBN) [Kibana images with preinstalled ReadonlyREST plugin in Docker Hub](https://hub.docker.com/r/beshultd/kibana-readonlyrest)
 * **🚀New** (KBN) 8.14.3, 8.14.2 support
 * **🚀New** (ES) 8.14.3, 8.14.2 support
-* **🚀New** (ES) ["structured groups" feature](https://github.com/beshu-tech/readonlyrest-docs/blob/develop/details/structured-groups.md) (authorization rules group names and group IDs can be defined separately) 
+* **🚀New** (ES) ["structured groups" feature](https://github.com/beshu-tech/readonlyrest-docs/blob/develop/details/structured-groups.md) (authorization rules group names and group IDs can be defined separately)
 * **🧐Enhancement** (KBN) New `readonlyrest_kbn.cookies.secure` and `readonlyrest_kbn.cookies.sameSite` cookie settings via kibana.yml
 * **🧐Enhancement** (ES) improved error logging on the creation of LDAP connectors
 * **🧐Enhancement** (ES) Patcher - invalid state after patching detection improvements
@@ -325,9 +311,9 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚀New** (KBN) 8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support
 * **🚀New** (ES) 8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support
 * **⚠️Warning** (ES) [for ES > 6.5 patching is required since this version of ROR](https://docs.readonlyrest.com/elasticsearch#id-5.-patch-elasticsearch)
-* **🧐Enhancement** (KBN) The activation key will be revalidated in the interval 
+* **🧐Enhancement** (KBN) The activation key will be revalidated in the interval
 * **🧐Enhancement** (KBN) Provide a way to define Activation key [retrieval mode](https://docs.readonlyrest.com/v/develop/universal-builds#change-activation-key-retrieval-mode-via-kibana.yml)
-* **🐞Fix** (KBN) Sometimes reports are not generated correctly for Kibana >= 8.0.0 and "Max attempt reached" error  appears 
+* **🐞Fix** (KBN) Sometimes reports are not generated correctly for Kibana >= 8.0.0 and "Max attempt reached" error  appears
 * **🐞Fix** (KBN) The OIDC scope configuration property was not applied and the default configuration was used instead.
 * **🐞Fix** (KBN) The OIDC proxy parameter was not handled properly in case of HTTPs connection over HTTP proxy server
 * **🐞Fix** (KBN) Missing information when Kibana is not patched
@@ -421,7 +407,7 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚀New** (KBN) 8.8.2, 8.8.1, 8.8.0, 7.17.11 support
 * **🚀New** (ES) 8.8.2, 7.17.11 support
 * **🚀New** (ES) [LDAP nested groups support](https://docs.readonlyrest.com/elasticsearch#ldap-connector)
-* **🧐Enhancement** (KBN) [Allow setting default tenancy via `/login?defaultGroup` query param. To be used with "Custom Middleware" feature for reordering available tenancies in the ROR menu](https://docs.readonlyrest.com/examples/custom-middleware/reordering-available-tenancies) 
+* **🧐Enhancement** (KBN) [Allow setting default tenancy via `/login?defaultGroup` query param. To be used with "Custom Middleware" feature for reordering available tenancies in the ROR menu](https://docs.readonlyrest.com/examples/custom-middleware/reordering-available-tenancies)
 * **🐞Fix** (ES) [Fix for ES warnings in logs about custom action names (ROR internal actions)](https://forum.readonlyrest.com/t/invalid-action-name-cluster-ror-audit-event-put/2186)
 * **🐞Fix** (ES) [kibana access `rw` and `admin` should allow to manage component templates](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372)
 
@@ -489,7 +475,7 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 ### (2022-12-05) What's new in **ROR 1.45.1**
 * **🚀New** (KBN) 8.5.3, 7.17.8 support
 * **🚀New** (ES) 8.5.3, 7.17.8 support
-* **🐞Fix** (KBN) ROR KBN patching script 
+* **🐞Fix** (KBN) ROR KBN patching script
 
 ### (2022-11-29) What's new in **ROR 1.45.0**
 * **🚨Security Fix** (ES) [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003), [CVE-2022-45146](https://nvd.nist.gov/vuln/detail/CVE-2022-45146)
@@ -498,8 +484,8 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚀New** (KBN) Inject CSS/JS files in login page
 * **🚀New** (KBN) Add user metadata to <body> for extra UI customization
 * **🚀New** (ES) Added groups_and mode to [groups_provider_authorization](https://docs.readonlyrest.com/elasticsearch#groups_provider_authorization) rule
-* **🧐Enhancement** (ES) all authorization rules support wildcards in group IDs 
-* **🧐Enhancement** (ES) connections in the LDAP pool should not be closed unnecessarily 
+* **🧐Enhancement** (ES) all authorization rules support wildcards in group IDs
+* **🧐Enhancement** (ES) connections in the LDAP pool should not be closed unnecessarily
 * **🧐Enhancement** (KBN) Deterministic reporting index detection
 * **🧐Enhancement** (KBN) Move free type impersonation to the local users area
 * **🧐Enhancement** (KBN) don't logout when initial JWT token expires
@@ -581,8 +567,8 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🚀New** (ES) [New `groups_and` ACL rule](https://docs.readonlyrest.com/elasticsearch#groups_and)
 * **🧐Enhancement** (KBN) Stop inlining whitelisted headers into Authorization header
 * **🧐Enhancement** (KBN) Log additional errors and info related to HA
-* **🧐Enhancement** (KBN) Misc internal dependencies upgrades 
-* **🐞Fix** (KBN) Mandatory elasticsearch credentials in kibana.yml 
+* **🧐Enhancement** (KBN) Misc internal dependencies upgrades
+* **🐞Fix** (KBN) Mandatory elasticsearch credentials in kibana.yml
 * **🐞Fix** (KBN) [Reporting page redirect on refresh when kibana_hide_apps: ["Stack Management"]](https://forum.readonlyrest.com/t/when-hiding-stack-management-a-redirect-appears-with-report/2088)
 * **🐞Fix** (KBN) whitelistedPaths: log errors when 404 occurs
 * **🐞Fix** (KBN) [Issue uploading large payload](https://forum.readonlyrest.com/t/issue-uploading-large-payload/2091)
@@ -635,14 +621,13 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🐞Fix** (KBN) More alerting fixes (only for main tenancy)
 
 ### (2021-10-12) What's new in **ROR 1.35.0**
-
 * **🚀New** (KBN) Support Kibana 7.15.0, 7.14.2
 * **🚀New** (ES) New Support for 7.15.1, 6.8.19, 6.8.20
 * **🧐Enhancement** (ES) [local->external groups detailed mapping for groups rule](https://github.com/beshu-tech/readonlyrest-docs/blob/master/details/groups-rule-mapping.md)
 * **🧐Enhancement** (ES) when ROR is starting any request is going to end up with HTTP 403 response, instead of HTTP 503
 * **🧐Enhancement** (KBN) "server.basePath" kibana option implementation
 * **🧐Enhancement** (KBN) Support full regex in kibana_hidden_apps rule
-* **🧐Enhancement** Crash if Kibana is not patched
+* **🧐Enhancement** (unspecified) Crash if Kibana is not patched
 * **🧐Enhancement** (KBN) Honour kibana setting "logging.dest"
 * **🧐Enhancement** (KBN) Confirm before overwriting audit log dashboard
 * **🐞Fix** (ES) verbosity: error fix in case of ROR KBN login request
@@ -654,7 +639,6 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🐞Fix** (KBN) Resolve browser console errors on a popover close
 
 ### (2021-09-24) What's new in **ROR 1.34.0**
-
 * **🚀New** (ES) New Support for 7.15.0, 7.14.2
 * **🚀New** (KBN) VS Code style YAML editor
 * **🚀New** (KBN) Skip rendering hidden app groups entirely
@@ -665,23 +649,20 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🐞Fix** (KBN) cookiePass config parsing broke load balancing
 
 ### (2021-08-14) What's new in **ROR 1.33.1**
-
 * **🚀New** (ES) New Support for 7.14.1
 * **🐞Fix** (KBN) Error in patching for 7.14.0
 * **🐞Fix** (KBN) clearSessionOnEvents now works as expected
 * **🐞Fix** (KBN) login form font loads correctly
 
 ### (2021-08-09) What's new in **ROR 1.33.0**
-
 * **🚨Security Fix** (KBN) xml-crypto dependency update
 * **🚀New** (KBN) New Support for 7.14.0, 6.8.18
 * **🧐Enhancement** (KBN) Parse credentials in /api/* requests, no need for valid cookie. Supersedes whitelistedPaths
-* **🐞Fix** (KBN)Caching issues switching tenancies with dark/light theme
+* **🐞Fix** (KBN) Caching issues switching tenancies with dark/light theme
 * **🐞Fix** (KBN) Newly created Space shows in all tenancies when using default kibana index
-* **🐞Fix** \(KBN &lt; 7.9.x\) nextUrl works again with SAML and OIDC
+* **🐞Fix** (KBN &lt; 7.9.x) nextUrl works again with SAML and OIDC
 
 ### (2021-07-25) What's new in **ROR 1.32.0**
-
 * **🚨Security Fix** (ES) [Apache Commons Codec vulnerability](https://forum.readonlyrest.com/t/security-vulnerability-for-common-codec-1-10/1906)
 * **🚨Security Fix** (KBN) upgraded dependencies due to security fixes
 * **🚨Security Fix** (KBN) disable x-powered-by to avoid fingerprinting
@@ -691,15 +672,14 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🧐Enhancement** (KBN) when metadata has no username, login must be denied
 * **🧐Enhancement** (KBN) audit tab ported to new platform
 * **🧐Enhancement** (ES) improved ES resources cleaning when ROR returns FORBIDDEN response
-* **🧐Enhancement** \(KBN &lt; 7.9.x\) auto clean-up dangling SAML/OIDC cookies
+* **🧐Enhancement** (KBN &lt; 7.9.x) auto clean-up dangling SAML/OIDC cookies
 * **🐞Fix** (ES) [incomplete response for request GET */_alias](https://forum.readonlyrest.com/t/ror-return-incomplete-response-for-request-get-alias/1872)
 * **🐞Fix** (ES) not allowed aliases should not present in a response for a Get Index API request
 * **🐞Fix** (KBN) fix dev-tools and import saved object not working
 * **🐞Fix** (KBN) honor `requestHeadersWhitelist` in user metadata request (login)
-* **🐞Fix** \(KBN &lt; 7.9.x\) do not crash on invalid metadata
- 
-### (2021-06-29) What's new in **ROR 1.31.0**
+* **🐞Fix** (KBN &lt; 7.9.x) do not crash on invalid metadata
 
+### (2021-06-29) What's new in **ROR 1.31.0**
 * **🚨Security Fix** (KBN) prevent direct navigation to hidden apps
 * **🚀New** (ES) 7.13.4, 7.13.3, 7.13.2, 6.8.17 support
 * **🚀New** (KBN) new minimal Kibana Management menu when "Management" app is hidden
@@ -716,570 +696,412 @@ Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API reque
 * **🐞Fix** (KBN) bad multipart POST handling leads to saved object import errors
 
 ### (2021-05-26) What's new in **ROR 1.30.1**
-
-* **🚨Security Fix** \(ES\) [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)
-* **🚀New** \(ES\) 7.13.0, 7.13.1 support
-* **🐞Fix** \(ES\) Regression in multi-tenancy handling
-* **🐞Fix** \(ES\) Proper handling of \_snapshot/\_status endpoint
+* **🚨Security Fix** (ES) [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)
+* **🚀New** (ES) 7.13.0, 7.13.1 support
+* **🐞Fix** (ES) Regression in multi-tenancy handling
+* **🐞Fix** (ES) Proper handling of \_snapshot/\_status endpoint
 
 ### (2021-05-16) What's new in **ROR 1.30.0**
-
-* **🚀New** \(KBN\) 7.12.x compatibility
-* **🚀New** \(ES\) [LDAP connector circuit breaker](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#circuit-breaker)
-* **🧐Enhancement** \(ES\) [Username with wildcard support in users section](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#groups) and [groups mapping](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#group-mapping)
-* **🧐Enhancement** \(KBN &lt; 7.9.x\) OIDC errors visibility
-* **🧐Enhancement** \(KBN &lt; 7.9.x\) Smarter session probe algorithm
-* **🐞Fix** \(KBN &gt;= 7.9.x\) [Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)
-* **🐞Fix** \(KBN &lt; 7.9.x\) Don't hide visualizations list search box in RO mode
+* **🚀New** (KBN) 7.12.x compatibility
+* **🚀New** (ES) [LDAP connector circuit breaker](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#circuit-breaker)
+* **🧐Enhancement** (ES) [Username with wildcard support in users section](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#groups) and [groups mapping](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#group-mapping)
+* **🧐Enhancement** (KBN &lt; 7.9.x) OIDC errors visibility
+* **🧐Enhancement** (KBN &lt; 7.9.x) Smarter session probe algorithm
+* **🐞Fix** (KBN &gt;= 7.9.x) [Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)
+* **🐞Fix** (KBN &lt; 7.9.x) Don't hide visualizations list search box in RO mode
 
 ### (2021-04-09) What's new in **ROR 1.29.0**
-
-* **🚨Security Fix** \(ES\) Security Fix \(ES\) [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409)
-* **🚀New** \(KBN\) support 7.9.0, 7.9.1, 7.10.0, 7.10.1, 7.10.2, 7.11.0, 7.11.1, 7.11.2 \([with ROR new platform](https://beta.readonlyrest.com/)\) 
-* **🚀New** \(ES\) 7.12.1 support 
-* **🧐Enhancement** \(KBN\) logout if the credentials/metadata of the current user change in the ACL
+* **🚨Security Fix** (ES) Security Fix (ES) [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409)
+* **🚀New** (KBN) support 7.9.0, 7.9.1, 7.10.0, 7.10.1, 7.10.2, 7.11.0, 7.11.1, 7.11.2 ([with ROR new platform](https://beta.readonlyrest.com/))
+* **🚀New** (ES) 7.12.1 support
+* **🧐Enhancement** (KBN) logout if the credentials/metadata of the current user change in the ACL
 
 ### (2021-04-01) What's new in **ROR 1.28.2**
-
-* **🚨Security Fix** \(ES\) [CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295)
-* **🐞Fix** \(KBN\) prevent SAML/OIDC initiated Kibana sessions from expiring after `session_timeout_minutes` despite continued interaction
+* **🚨Security Fix** (ES) [CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295)
+* **🐞Fix** (KBN) prevent SAML/OIDC initiated Kibana sessions from expiring after `session_timeout_minutes` despite continued interaction
 
 ### (2021-03-24) What's new in **ROR 1.28.1**
-
-* **🐞Fix** \(ES\) Getting index templates issue when no `indices` rule was used in matched block
-* **🐞Fix** \(ES\) [NPE on getting template aliases](https://forum.readonlyrest.com/t/cannot-put-index-template-template-1/1681/25)
+* **🐞Fix** (ES) Getting index templates issue when no `indices` rule was used in matched block
+* **🐞Fix** (ES) [NPE on getting template aliases](https://forum.readonlyrest.com/t/cannot-put-index-template-template-1/1681/25)
 
 ### (2021-03-14) What's new in **ROR 1.28.0**
-
-* **🚀New** \(ES\) 7.12.0, 7.11.2 support 
-* **🚀New** \(ES\) full [Index and Component Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/index-templates.html) support 
-* **🧐Enhancement** \(ES\) [Username case sensitivity settings](https://forum.readonlyrest.com/t/ldap-based-user-authentication/1667)
-* **🐞Fix** \(ES\) [Kibana logout event storing fix](https://forum.readonlyrest.com/t/kibana-plugin-software-licensing-and-expiration/1808/5)
-* **🐞Fix** \(ES\) [Fixed remote reindex operation with "type" parameter](https://forum.readonlyrest.com/t/reindex-index-not-found-exception/1708/20)
-* **🐞Fix** \(KBN\) Prevent cookie expiration deadlock in browsers when using SAML/OIDC
-* **🐞Fix** \(KBN\) When credentials change in the ACL, make it possible to login again
-* **🐞Fix** \(KBN\) Kibana management app ID changed from "kibana:management" to "kibana:stack\_management"
+* **🚀New** (ES) 7.12.0, 7.11.2 support
+* **🚀New** (ES) full [Index and Component Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/index-templates.html) support
+* **🧐Enhancement** (ES) [Username case sensitivity settings](https://forum.readonlyrest.com/t/ldap-based-user-authentication/1667)
+* **🐞Fix** (ES) [Kibana logout event storing fix](https://forum.readonlyrest.com/t/kibana-plugin-software-licensing-and-expiration/1808/5)
+* **🐞Fix** (ES) [Fixed remote reindex operation with "type" parameter](https://forum.readonlyrest.com/t/reindex-index-not-found-exception/1708/20)
+* **🐞Fix** (KBN) Prevent cookie expiration deadlock in browsers when using SAML/OIDC
+* **🐞Fix** (KBN) When credentials change in the ACL, make it possible to login again
+* **🐞Fix** (KBN) Kibana management app ID changed from "kibana:management" to "kibana:stack\_management"
 
 ### (2021-02-27) What's new in **ROR 1.27.1**
-
-* **🚨Security Fix** \(ES\) [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290)
-* **🚀New** \(ES\) 7.11.1 support 
+* **🚨Security Fix** (ES) [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290)
+* **🚀New** (ES) 7.11.1 support
 
 ### (2021-02-16) What's new in **ROR 1.27.0**
-
-* **🚀New** \(ES\) 7.11.0, 7.10.2, 6.8.14 support
-* **🧐Enhancement** \(KBN\) X-Forwarded-For copied from incoming request \(or filled with source IP\) before forwarding to ES
-* **🧐Enhancement** \(KBN\) Kibana logout event generates a special audit log entry in ROR audit logs index
-* **🧐Enhancement** \(KBN\) ROR panel shows "reports" button if kibana:management app is hidden
-* **🐞Fix** \(ES\) [blocks containing filter and/or fields won't match internal kibana requests, so kibana\_\* rules won't have to be placed in such blocks](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#fields)
-* **🐞Fix** \(ES\) SQL API - better handling of invalid query
+* **🚀New** (ES) 7.11.0, 7.10.2, 6.8.14 support
+* **🧐Enhancement** (KBN) X-Forwarded-For copied from incoming request (or filled with source IP) before forwarding to ES
+* **🧐Enhancement** (KBN) Kibana logout event generates a special audit log entry in ROR audit logs index
+* **🧐Enhancement** (KBN) ROR panel shows "reports" button if kibana:management app is hidden
+* **🐞Fix** (ES) [blocks containing filter and/or fields won't match internal kibana requests, so kibana\_\* rules won't have to be placed in such blocks](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#fields)
+* **🐞Fix** (ES) SQL API - better handling of invalid query
 
 ### (2021-01-11) What's new in **ROR 1.26.1**
-
-* **🐞Fix** \(ES\) wrong behaviour of `kibana_access` rule for ROR actions when ADMIN value is set
+* **🐞Fix** (ES) wrong behaviour of `kibana_access` rule for ROR actions when ADMIN value is set
 
 ### (2021-01-02) What's new in **ROR 1.26.0**
-
-* **🚨Security Fix** \(ES\) [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) & [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) \(removed Jackson dependency from ROR core\)
-* **🚀New** \(ES\) [New response\_fields rule](https://forum.readonlyrest.com/t/ror-1-18-9-enterprise-es-7-2-0-enable-cluster-health-without-authentication/1567)
-* **🚀New** \(ES\) [Support for LDAP server discovery using \_ldaps.\_tcp SRV record](https://forum.readonlyrest.com/t/does-ror-support-dc-locator/1211)
-* **🚀 New** \(ES\) [New configuration option allowing to ignore LDAP connectivity problems](https://forum.readonlyrest.com/t/ror-cannot-start-if-ldap-is-not-available/1748)
-* **🧐Enhancement** \(ES\) Full support for ILM API
-* **🧐Enhancement** \(KBN\) Enforce read-after-write consistency between kibana nodes
-* **🧐Enhancement** \(KBN ENT\) OIDC custom claims incorporated in "assertion" claim
-* **🧐Enhancement** \(KBN ENT\) OIDC support for configurable kibanaExternalHost \(good for Docker\)
-* **🧐Enhancement** \(KBN ENT\) ROR adds "ror-user\_" class to "body" tag for easy per-user CSS/JS
-* **🧐Enhancement** \(KBN ENT/PRO\) ROR adds "ror-group\_" class to "body" tag for easy per-group CSS/JS
-* **🐞Fix** \(ES\) [ROR authentication endpoint action](https://forum.readonlyrest.com/t/es-7-4-2-ror-1-18-9-rradmin-refreshsettings-by-block-default/1388)
-* **🐞Fix** \(ES\) "username" in audit entry when request is rejected
-
-### What's new in 1.25.2
-
-* **🐞Fix** \(ES\) [removed verbose logging](https://forum.readonlyrest.com/t/elastic-message-cannot-extract-fields-for-query-after-readonlyrest-installation/1749)
-
-### What's new in 1.25.1
-
-* **🚨Security Fix** \(ES\) [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)
-* **🚀New** \(ES\) 7.10.1 support
-
-### What's new in 1.25.0
-
-* **🚨Security Fix** \(ES\) [Common Vulnerabilities and Exposures \(CVE\)](https://forum.readonlyrest.com/t/update-of-jackson-databind-2-9-6-jar/176)
-* **🚀New** \(ES\) 7.10.0 support
-* **🚀New** \(ES\) [auth\_key\_pbkdf2 rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#auth_key_pbkdf2)
-* **🚀New** \(ES\) [Introduced configuration property defining FLS engine used by fields rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#fields)
-* **🧐Enhancement** \(ES\) Fields rule performance improvement
-* **🧐Enhancement** \(ES\) Resolved index API support
-* **🐞Fix** \(ES\) ["username" in audit entry when user is authenticated via proxy\_auth](https://forum.readonlyrest.com/t/ror-audit-not-logging-user-id)
-* **🐞Fix** \(ES\) index resolve action should be treated as readonly action
-* **🐞Fix** \(ES\) /\_snapshot and /\_snapshot/\_all should behave the same
-
-### What's new in 1.24.0
-
-* **🚨Security Fix** \(ES\) search template handling fix
-* **🚀New** \(ES\) 7.9.3 & 6.8.13 support
-* **🧐Enhancement** \(ES\) full support for ES Snapshots and Restore APIs
-* **🐞Fix** \(KBN\) fix crash in error handling
-* **🐞Fix** \(ES\) don't remove ES response warning headers
-* **🐞Fix** \(ES\) issue when entropy of /dev/random could have been exhausted when using JwtToken rule
-
-### What's new in 1.23.1
-
-* **🚀New** \(ES\) 7.9.2 support
-* **🐞Fix** \(KBN\) fix code 500 error on login in Kibana
-
-### What's new in 1.23.0
-
-* **🚀New** \(ES\) introduced must\_involve\_indices option for indices rule
-* **🧐Enhancement** \(ES\) negation support in headers rules
-* **🧐Enhancement** \(ES\) [x-pack rollup API handling](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)
-* **🐞Fix** \(KBN\) deep links query parameters are now handled
-* **🐞Fix** \(KBN\) make sure default kibana index is always discovered \(fixes reporting in 6.x\)
-* **🐞Fix** \(ES\) [settings file permission issue with JDK 1.8.0 25.262-b10](https://forum.readonlyrest.com/t/readonlyrest-for-elastic-wont-start-1-18-8-es6-8-1/1652)
-* **🐞Fix** \(ES\) /\_cluster/allocation/explain request should not be forbidden if matched block doesn't have indices rules
-* **🐞Fix** \(ES\) remote address extracting issue
-* **🐞Fix** \(ES\) [fixed TYP audit field for some request types](https://forum.readonlyrest.com/t/match-wrong-index-in-forbid-block/1653/2)
-
-### What's new in 1.22.1
-
-* **🐞Fix** \(ES\) missing handling of aliases API for ES 7.9.0
-
-### What's new in 1.22.0
-
-* **🚀New** \(ES\) 7.9.0 support
-* **🧐Enhancement** \(ES\) aliases API handling
-* **🧐Enhancement** \(ES\) dynamic variables support in fields rule
-* **🐞Fix** \(ES\) [adding aliases issue](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)
-* **🐞Fix** \(ES\) potential memory leak for ES 7.7.x and above
-* **🐞Fix** \(ES\) cross cluster search issue fix for X-Pack \_async\_search action
-* **🐞Fix** \(ES\) XFF entry in audit issue
-* **🐞Fix** \(KBN\) SAML certificate loading
-* **🐞Fix** \(KBN\) SAML loading groups from assertion
-* **🐞Fix** \(KBN\) fix reporting in pre-7.7.0
-
-### What's new in 1.21.0
-
-* **🧐Enhancement** \(ES\) [cluster API support improvements](https://forum.readonlyrest.com/t/settings-problems/1616)
-* **🐞Fix** \(ES\) X-Pack \_async\_search support
-* **🐞Fix** \(ES\) \_rollover request handling
-* **🐞Fix** \(ES\) [handling numeric ssl configuration properties](https://forum.readonlyrest.com/t/numeric-passphrases-invalid-ssl-config/1512)
-* **🐞Fix** \(KBN\) multitenancy+reporting regression fix \(for 7.6.x and earlier\)
-* **🐞Fix** \(KBN\) "x-" headers should be forwarded in /login route when proxy passthrough is enabled
-* **🐞Fix** [\(KBN\) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)
-* **🐞Fix** \(KBN\) SAML metadata.xml endpoint not responding
-* **🐞Fix** \(KBN\) NAT/reverse proxy support for SAML
-* **🐞Fix** \(KBN\) SAML login redirect error
-* **🐞Fix** \(ES\) \_readonlyrest/metadata/current\_user should be always allowed by filter/fields rule
-
-### What's new in 1.20.0
-
-* **🚀New** 7.7.1, 7.8.0 support
-* **🧐Enhancement** \(KBN\) tidy up audit page
-* **🧐Enhancement** \(KBN FREE\) clearly inform when features are not available
-* **🧐Enhancement** \(KBN\) ship license report of libraries
-* **🧐Enhancement** \(ES\) filter rule performance improvement
-* **🐞Fix** \(KBN\) proxy\_auth: avoid logout-login loop
-* **🐞Fix** \(KBN\) 404 error on font CSS file
-* **🐞Fix** \(ES\) [wildcard in filter query issue](https://forum.readonlyrest.com/t/wildcard-in-dls-filter-gives-error/1551)
-* **🐞Fix** \(ES\) [forbidden /\_snapshot issue](https://forum.readonlyrest.com/t/get-snapshot-permission-issue/1594)
-* **🐞Fix** \(ES\) /\_mget handling by indices rule when no index from a list is found
-* **🐞Fix** \(ES\) available groups order in metadata response should match the order in which groups appear in ACL
-* **🐞Fix** \(ES\) .readonlyrest and audit index - removed usage of explicit index type
-* **🐞Fix** \(ES\) [tasks leak bug](https://forum.readonlyrest.com/t/lots-of-active-tasks-in-cat-tasks/1593)
-
-### What's new in 1.19.5
-
-* **🚀New** 7.7.0, 7.6.2, 6.8.9, 6.8.8 support
-* **🧐Enhancement** \(ES/KBN\) kibana\_access can be explicitly set to unrestricted
-* **🧐Enhancement** \(ES\) [LDAP connection pool improvement](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)
-* **🐞Fix** \(ES\) [better LDAP request timeout handling](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)
-* **🐞Fix** \(ES\) remote indices searching bug
-* **🐞Fix** \(ES\) cross cluster search support for \_field\_caps request
-* **🚨Security Fix** \(ES\) create and delete templates handling
-* **🐞Fix** \(KBN\) Regression in proxy\_auth\_passthrough
-* **🧐Enhancement** \(KBN\) whitelistedPaths now accepts basic auth credentials
-* **🧐Enhancement** \(KBN\) Dump logout button, [new ROR Panel](https://forum.readonlyrest.com/t/new-logout-button-design-new-ror-panel/1476)
-* **🧐Enhancement** \(KBN\) removed ROR from Kibana sidebar. Admins have a link in new panel.
-* **🧐Enhancement** \(KBN\) avoid show login form redirecting from SAML IdP
-* **🚀New** \(KBN\) [OpenID Connect \(OIDC\) authentication connector](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#openid-connect-oidc)
-* **🚀New** \(KBN\) [login\_title, login\_subtitle enable 2 column login page](https://forum.readonlyrest.com/t/ror-enterprise-show-support-contact-on-login-page/1508/2)
-* **🚨Security Fix** \(KBN\) server-side navigation prevention to hidden apps
-
-### What's new in 1.19.4
-
-* **🐞Fix** \(ES\) Interpolating config with environment variables in SSL section
-* **🐞Fix** \(KBN Ent 6.x\) Fixed default space creation in
-* **🐞Fix** \(KBN 6.x\) Fixed error toast notification not showing
-* **🐞Fix** \(KBN Ent\) Fixed missing Axios dependency
-* **🐞Fix** \(KBN Ent\) Fixed SAML connector
-* **🐞Fix** \(KBN\) Toast notification overlap with logout bar
-* **🧐Enhancement** \(KBN\) Restyled logout bar
-* **🧐Enhancement** \(KBN\) Configurable periodic session checker
-
-### What's new in 1.19.3
-
-* **🚀New** \(ES/KBN\) 7.6.1 compatibility
-* **🚀New** \(ES\) customizable name of settings index
-* **🧐Enhancement** \(KBN\) configurable ROR cookie name
-* **🧐Enhancement** \(ES/KBN\) handling of encoded ROR headers in Authorization header values
-* **🧐Enhancement** \(KBN\) user feedback on why login failed
-* **🐞Fix** \(ES\) support for multiple header values
-* **🐞Fix** \(ES\) releasing LDAP connection pool on reloading ROR settings
-* **🐞Fix** \(KBN\) multitenancy issue with 7.6.0+
-* **🐞Fix** \(KBN\) creation of default space for new tenant
-* **🐞Fix** \(KBN 6.x\) in RO mode, don't hide add/remove over fields in discovery
-* **🐞Fix** \(KBN 6.x\) index template & in-index session manager issues
-
-### What's new in 1.19.2
-
-* **🚀New** \(KBN\) 7.6.0 support
-* **🧐Enhancement** \(KBN\) less verbose info logging
-* **🧐Enhancement** \(KBN\) start up time semantic check for settings
-* **🐞Fix** \(KBN Free\) missing logout button
-* **🐞Fix** \(KBN\) error message creating internal proxy
-* **🐞Fix** \(KBN 6.x\) add field to filter button invisible in RO mode
-
-### What's new in 1.19.1
-
-* **🎁Product** \(KBN\) [Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)
-* **🚀New** \(ES\) 7.6.0 support, Kibana support coming soon
-* **🚀New** \(KBN\) Audit log dashboard
-* **🚀New** \(KBN\) Template index can now be declared per tenant instead of globally
-* **🚀New** \(ES\) custom trust store file and password options in ROR settings
-* **🧐Enhancement** \(ES\) When "prompt\_for\_basic\_auth" is enabled, ROR is going to return 401 instead of 404 when the index is not found or a user is not allowed to see the index
-* **🧐Enhancement** \(ES\) literal ipv6 with zone Id is acceptable network address
-* **🧐Enhancement** \(ES\) LDAP client cache improvements
-* **🐞Fix** \(ES\) /\_all/\_settings API issue
-* **🐞Fix** \(ES\) Index stats API & Index shard stores API issue
-* **🐞Fix** \(ES\) readonlyrest.force\_load\_from\_file setting decoding issue
-* **🐞Fix** \(KBN\) allowing user to be logged in in two tabs at the same time
-* **🐞Fix** \(KBN\) logging with JWT parameter issue
-* **🐞Fix** \(KBN\) parsing of sessions fetched from ES index
-* **🐞Fix** \(KBN\) logout issue
-
-### What's new in 1.19.0
-
-* **🚀New** \(KBN\) Configurable option to delete docs from tenant index when not present in template
-* **🧐Enhancement** \(ES\) Less verbose logging of blocks history
-* **🧐Enhancement** \(ES\) Enriched logs and audit with attempted username
-* **🧐Enhancement** \(ES\) Better settings validation - only one authentication rule can be used in given block
-* **🧐Enhancement** \(ES/KBN\) Plugin versions printing in logs on launch
-* **🧐Enhancement** \(ES\) When user doesn't have access to given index, ROR pretends that the index doesn't exist and return 404 instead of 403
-* **🐞Fix** \(ES\) Searching for nonexistent/forbidden index with wildcard mirrors default ES behaviour instead of returning 403
-* **🐞Fix** \(KBN\) Switching groups bug
-
-### What's new in 1.18.10
-
-* **🚀New** \(ES/KBN\) Support v6.8.6, v7.5.0, v7.5.1
-* **🚀New** \(KBN\) Group IDs can now be mapped to aliases
-* **🚀New** \(ES\) New, more robust and simple method of creating custom audit log serializers
-* **🚀New** \(ES\) Example projects with custom audit log serializers
-* 🐞**Fix** \(KBN\) Prevent index migration after kibana startup
-* **🧐Enhancement** \(KBN\) If default space doesn't exist in kibana index then copy from default one
-* **🧐Enhancement** \(KBN\) Crypto improvements - store init vector with encrypted data as base64 encoded json.
-* **🧐Enhancement** \(ES\) Better settings validation - prevent duplicated keys in readonlyrest.yml
-
-### What's new in 1.18.9
-
-* **🚀New** \(ES/KBN\) Support v7.4.1, v7.4.2
-* **🚀New** \(KBN\) Kibana sessions stored in ES index
-* 🐞**Fix** \(ES\) issue with in-index settings auto-reloading
-* 🐞**Fix** \(ES\) \_cat/indices empty response when matched block doesn't contain 'indices' rule
-
-### What's new in 1.18.8
-
-* **🚀New** \(ES/KBN\) Support v7.4.0
-* **🚀New** \(ES\) Elasticsearch SQL Support
-* **🚀New** \(ES\) Internode ssl support for es5x, es60x, es61x and es62x
-* **🚀New** \(ES\) new runtime variable @{acl:current\_group}
-* **🚀New** \(ES\) namespace for user variable and support for both versions: @{user} and @{acl:user}
-* **🚀New** \(ES\) support for multiple values in uri\_re rule
-* **🧐Enhancement** \(ES\) more reliable in-index settings loading of ES with ROR startup
-* **🧐Enhancement** \(ES\) less verbose logs in JWT rules
-* **🧐Enhancement** \(ES\) Better response from ROR API when plugin is disabled
-* **🧐Enhancement** \(ES\) Splitting verification ssl property to client\_authentication and certificate\_verification
-* **🐞Fix** \(ES\) issue with backward compatibility of proxy\_auth settings
-* **🐞Fix** \(ES\) /\_render/template request NPE
-* **🐞Fix** \(ES\) \_cat/indices API bug fixes
-* **🐞Fix** \(ES\) \_cat/templates API return empty list instead of FORBIDDEN when no indices are found
-* **🐞Fix** \(ES\) updated regex for kibana access rule to support 7.3 ES
-* **🐞Fix** \(ES\) proper resolving of non-string ENV variables in readonlyrest.yml
-* **🐞Fix** \(ES\) lang-mustache search template handling
-
-### What's new in 1.18.7
-
-* **🚀New** \(ES\) Field level security \(FLS\) supports nested JSON fields
-* **🐞Security Fix** \(ES\) Authorization headers appeared in clear in logs
-* **🧐Enhancement** \(KBN\) Don't logout users when they are not allowed to search a index-pattern
-* **🧐Enhancement** \(ES\) Headers obfuscation is now case insensitive
-
-### What's new in 1.18.6
-
-* **🚀New** \(ES/KBN\) Support v7.3.1, v7.3.2
-* **🚀New** \(ES\) Configurable header names whose value should be obfuscated in logs
-* **🚀New** \(KBN\) Dynamic variables from user identity available in custom\_logout\_link
-* **🧐Enhancement** \(ES\) Richer logs for JWT errors
-* **🧐Enhancement** \(ENT\) nextUrl works also with SAML now
-* **🧐Enhancement** \(ENT\) SAML assertion object available in ACL dynamic variables
-* **🧐Enhancement** \(KBN\) Validate LDAP server\(s\) before accepting new YAML settings
-* **🧐Enhancement** \(KBN\) Ensure a read-only UX for 'ro' users in older Kibana
-* **🐞Fix** \(ES\) Fix memory leak from dependency \(snakeYAML\)
-
-### What's new in 1.18.5
-
-* **🐞Security Fix** \(ES\) indices rule can now properly handle also the templates API
-* **🧐Enhancement** \(ES\) Array dynamic variables are serialized as CSV wrapped in double quotes
-* **🧐Enhancement** \(ES\) Cleaner debug logs \(no stacktraces on forbidden requests\)
-* **🧐Enhancement** \(ES\) LDAP debug logs fire also when cache is hit
-* **🚀New** \(ES/KBN\) Support v7.2.1, v7.3.0
-* **🐞Fix** \(PRO\) PRO plugin crashing for some Kibana versions
-* **🐞Fix** \(ENT\) SAML library wrote a too large cookie sometimes
-* **🐞Fix** \(ENT\) SAML logout not working
-* **🐞Fix** \(ENT\) JWT fix exception "cannot set requestHeadersWhitelist"
-* **🐞Fix** \(PRO/ENT\) Hide more UI elements for RO users
-* **🐞Fix** \(PRO/ENT\) Sometimes not all the available groups appear in tenancy selector
-* **🐞Fix** \(PRO/ENT\) Feature "nextUrl" broke
-* **🐞Fix** \(PRO/ENT\) prevent user kick-out when APM is not configured and you are not an admin
-* **🚀New** \(PRO/ENT\) Kibana request path/method now sent to ES \(good for policing dev-tools\)
-
-### What's new in 1.18.4
-
-* **🚀New** \(ES\) User impersonation API
-* **🚀New** \(ES\) Support latest 6.x and 5.x versions
-* **🐞Security Fix** \(ES\) filter/fields rules leak
-* **🐞Fix** \(KBN/ENT\) allow more action for kibana\_access, prevent sudden logout
-* **🐞Fix** \(KBN/ENT\) temporarily roll back "support for unlimited tenancies"
-
-### What's new in 1.18.3
-
-* **🚀New** Support added for ES/Kibana 6.8.1
-* **🧐Enhancement** \(ES\) Crash ES on invalid settings instead of stalling forever
-* **🧐Enhancement** \(ES\) Better logging on JWT, JSON-paths, LDAP, YAML errors
-* **🧐Enhancement** \(ES\) Block level settings validation to user with precious hints
-* **🧐Enhancement** \(ES\) If force\_load\_from\_file: true, don't poll index settings
-* **🧐Enhancement** \(ES\) Order now counts declaring LDAP Failover HA servers
-* **🐞Fix** \(ES\) "EsIndexJsonContentProvider" had a null pointer exception
-* **🐞Fix** \(ES\) "es.set.netty.runtime.available.processors" exception
-* **🧐Enhancement** \(KBN\) Collapsible logout button
-* **🧐Enhancement** \(KBN\) ROR App now uses a HA http client
-* **🧐Enhancement** \(KBN\) Automatic logout for inactivity
-* **🧐Enhancement** \(KBN\) Support unlimited amount of tenancies
-* **🐞Fix** \(KBN/ENT\) concurrent multitenancy bug
-* **🐞Fix** \(KBN\) Avoid sporadic errors on Save/Load buttons
-
-### What's new in 1.18.2
-
-* **🚀New** Support for Elasticsearch & Kibana 7.2.0
-* **🐞Fix** \(ES\) restore indices \("IDX"\) in audit logging
-* **🧐Enhancement** \(ES\) New algorithm of setting evaluation order
-* **🚀New** \(ES\) JWT claims as dynamic variables. I.e. "@{jwt:claim.json.path}"
-* **🚀New** \(ES\) "explode" dynamic variables. I.e. indices: \["@explode{x-indices}"\]
-* **🐞Fix** \(PRO/Enterprise\) preserve comments and formatting in YAML editor
-* **🐞Fix** \(PRO/Enterprise\) Print error message when session is expired
-* **🐞Regression** \(PRO/Enterprise\) Redirect to original link after login
-* **🐞Regression** \(PRO/Enterprise\) Broken CSV reporting
-* **🧐Enhancement** \(PRO/Enterprise\) Prevent navigating away from YAML editor w/ unsaved changes
-* **🐞Fix** \(Enterprise\) Exception when SAML connectors were all disabled
-* **🐞Fix** \(Enterprise\) Concurrent tenants could mix up each other kibana index
-* **🐞Fix** \(Enterprise\) Cannot inject custom JS if no custom CSS was also declared
-* **🐞Fix** \(Enterprise\) Injected JS had no effect on ROR logout button
-* **🐞Fix** \(Enterprise\) On narrow screens, the YAML editor showed buttons twice
-
-### What's new in 1.18.1
-
-* **🐞Fix** \(Elasticsearch\) Reindex requests failed for a regression in indices extraction
-* **🐞Fix** \(Elasticsearch\) Groups rule erratically failed
-* **🐞Fix** \(Elasticsearch\) JWT claims can now contain special characters
-* **🧐Enhancement** \(Elasticsearch\) Better ACL History logging
-* **🧐Enhancement** \(Elasticsearch\) QueryLogSerializer and old custom log serializers work again
-* **🐞Fix** \(PRO/Enterprise\) ReadonlyREST icon in Kibana was white on white
-* **🐞Fix** \(Enterprise\) SAML connectors could not be disabled
-* **🐞Fix** \(Enterprise\) SAML connector "buttonName" didn't work
-
-### What's new in 1.18.0
-
-* **🚀New** Support for Elasticsearch & Kibana 7.0.1
-* **🧐Enhancement** \(Elasticsearch\) empty array values in settings are invalid
-* **🐞Security Fix** \(Elasticsearch\) arbitrary x-cluster search referencing local cluster
-* **🐞Fix** \(Elasticsearch\) ArrayOutOfBoundException on snapshot operations
-* **🧐Enhancement** \(PRO/Enterprise\) History cleaning can now be disabled \("clearSessionOnEvents"\)
-
-### What's new in 1.17.7
-
-* **🚀New** Support for Elasticsearch 7.0.0 \(Kibana is coming soon\)
-* **🧐Enhancement** \(Elasticsearch\) rewritten LDAP connector
-* **🧐Enhancement** \(Elasticsearch\) new core written in Scala is now GA
-* **🐞Fix** \(Enterprise\) devtools requests now honor the currently selected tenancy
-* **🐞Security Fix** \(Enterprise/PRO\) Fix "connectorsService" error in installation
-
-### What's new in 1.17.5
-
-* **🚀New** Support for Kibana/Elasticsearch 6.7.1
-* **🧐Enhancement** \(Enterprise &gt;= Kibana 6.6.0\) Multiple SAML identity provider
-* **🐞Security Fix** \(Enterprise/PRO\) Don't pass auth headers back to the browser
-* **🐞Fix** \(Enterprise/PRO\) Missing null check caused error in reporting \(CSV\)
-* **🐞Fix** \(Enterprise\) Don't reject requests if SAML groups are not configured
-* **🐞Fix** filter/fields rules not working in msearch \(in 6.7.x\)
-* **🧐Enhancement** Print whole LDAP search query in debug log
-
-### What's new in 1.17.4
-
-* **🚀New** Support for Kibana/Elasticsearch 6.7.0
-* **🧐Enhancement** \(PRO/Enterprise\) JWT query param is the preferred credentials provider
-* **🧐Enhancement** \(PRO/Enterprise\) admin users can use indices management
-* **🧐Enhancement** \(PRO/Enterprise\) ro users can dismiss telemetry form
-* **🐞Fix** Audit logging in 5.1.x now works again
-* **🐞Fix** unpredictable behaviour of "filter" and "fields" when using external auth
-* **🐞Fix** LDAP ConcurrentModificationException
-* **🐞Fix** Audit logging in 5.1.x now works again
-* **🐞Fix** \(PRO/Enterprise\) JWT deep-link works again
-
-### What's new in 1.17.3
-
-1.17.2 went unreleased, all changes have been merged in 1.17.3 directly
-
-* **🐞Fix** \(Enterprise\) Tenancy selector showing if user belonged to one group
-* **🐞Fix** \(PRO/Enterprise\) RW buttons not hiding for RO users in React Kibana apps
-* **🐞Fix** \(Enterprise\) Tenancy templating now works much more reliably
-* **🐞Fix** \(Enterprise\) Missing tenancy selector icon after switching tenancy
-* **🐞Fix** \(PRO/Enterprise\) barring static files requests caused sudden logout
-* **🐞Fix** Numerous fixes to better support Kibana 6.6.x
-* **🐞Fix** Critical fixes in new Scala core
-* **🐞Fix** Exception in reindex requests caused tenancy templating to fail
-* **🧐Enhancement** Bypass cross-cluster search logic if single cluster
-
-### What's new in 1.17.1
-
-* **🐞Fix** \(PRO/Enterprise\) SAML now works well in 6.6.x
-* **🐞Fix** \(PRO/Enterprise\) "undefined" authentication error before login
-* **🐞Fix** \(Enterprise\) Default space creation failures for new tenants
-* **🐞Fix** \(Enterprise\) Icons/titles CSS misalignment in sidebar \(Firefox\)
-* **🧐Enhancement**\(Enterprise\) UX: Larger tenancy selector
-* **🐞Security Fix** \(Enterprise\) Privilege escalation when changing tenancies under monitoring
-* **🐞Fix** \(Elasticsearch\) compatibility fixes to support new Kibana features
-* **🧐Enhancements** \(Elasticsearch\) New core and LDAP connector written in Scala is finished, now under QA.
-
-### What's new in 1.17.0
-
-* **🚀New Feature** Support for Kibana/Elasticsearch 6.6.0, 6.6.1
-* **🚀New Feature** Internode SSL \(ES 6.3.x onwards\)
-* **🧐Enhancement**\(PRO/Enterprise\) UI appearence
-* **🧐Enhancement** Made HTTP Connection configurable \(PR \#410\)
-* **🐞Fix** slow boot due to SecureRandom waiting for sufficient entropy
-* **🐞Fix** Enable kibana\_access:ro to create short urls in es6.3+ \(PR \#408\)
-
-### What's new in 1.16.34
-
-* **🧐Enhancement** X-Forwarded-For header in printed es logs \("XFF"\)
-* **🧐Enhancement** kibana_index: ".kibana_@{user}" when user is "John Doe" becomes .kibana\_john\_doe
-* **🐞Fix** \(Enteprise\) parse SAML groups from assertion as array of strings
-* **🐞Fix** \(Enteprise\) SAMLRequest in location header was URLEncoded twice, broke on some IdP
-* **🐞Fix** \(PRO/Enteprise\) "cookiePass" works again, no more need for sticky cookies in load balancers!
-* **🐞Fix** \(PRO/Enteprise\) fix redirect loop with JWT deep linking when JWT token expires
-* **🧐Enhancement** \(PRO/Enteprise\) fix audit demo page CSS
-* **🧐Enhancement** \(Enteprise\) SAML more configuration parameters available
-* **🚀New Feature** \(PRO/Enteprise\) set ROR to debug mode \(readonlyrest\_kbn.logLevel: "debug"\)
-
-### What's new in 1.16.33
-
-* **🐞Fix**\(PRO/Enteprise\) compatibility problems with older Kibana versions
-* **🐞Fix**\(PRO/Enteprise\) compatibility problems with OSS Kibana version
-
-### What's new in 1.16.32
-
-* **🚀New Feature** "kibanaIndexTemplate": default dashboards and spaces for new tenants
-* **🧐Enhancement** Support for ES/Kibana 6.5.4
-* **🧐Enhancement** Upgraded LDAP library
-* **🧐Enhancement** \(Enterprise\) Now tenants save their CSV exports in their own reporting index
-* **🐞Fix**\(PRO/Enteprise\) Support passwords that start and/or end with spaces
-* **🐞Fix** \(PRO/Enterprise\) Now reporting works again
-
-### What's new in 1.16.31
-
-* **🧐Enhancement** Support for ES/Kibana 6.5.2, 6.5.3
-* **🚧WIP**: Laid out the foundation for LDAP HA support
-
-### What's new in 1.16.29
-
-* **🧐Enhancement** Support for ES/Kibana 6.4.3
-* **🚀New Feature** \(PRO/Enterprise\) configurable server side session duration
-* **🚀New Feature** \[LDAP\] High Availability: Round Robin or Failover
-
-### What's new in 1.16.28
-
-* **🧐Enhancement** Support for ES/Kibana 6.4.2
-* **🐞Fix** \(Enterprise\) Multi tenancy: sometimes changing tenancy would not change kibana index
-* **🐞Security Fix** \(Enterprise/PRO\) Avoid echoing Base64 encoded credentials in login form error message
-* **🧐Enhancement** \(Enterprise/PRO\) Remove latest search/visualization/dashboard history on logout
-* **🧐Enhancement** \(Enterprise/PRO\) Clear transient authentication cookies on login error to avoid authentication deadlocks
-* **🐞Fix**: External JWT verification may throw ArrayOutOfBoundException
-* **🚧WIP**: Laid out the foundation for internode SSL transport \(port 9300\)
-
-### What's new in 1.16.27
-
-* **🚀New Feature** \[JWT\] external validator: it's now possible to avoid storing the private key in settings
-* **🧐Enhancement** Support for ES/Kibana 6.4.1
-* **🧐Enhancement** Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)
-* **🧐Enhancement** SAML Single log out flow
-* **🐞Fix** \(Enterprise/PRO\) [cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB.
-* **🧐Enhancement** \(Enterprise/PRO\) much faster logout
-
-### What's new in 1.16.26
-
-* **🐞 Fix** \(PRO/Enterprise\) bugs during plugin packaging and installation process
-
-### What's new in 1.16.25
-
-* **🚀New Feature** Users rule: easily restrict external authentication to a list of users
-* **🧐Enhancement** Support for ES 5.6.11
-* **🐞Hot Fix** \(Enterprise/PRO\) Error 404 when logging in with older versions of Kibana
-
-### What's new in 1.16.24
-
-* **🚀New Feature** \(Enterprise\) SAML Authentication
-* **🚀New Feature** Support for Elasticsearch and Kibana 6.4.0
-* **🚀New Feature** Headers rule now split in headers\_or and headers\_and
-* **🧐Enhancement** Headers rule now allows wildcards
-* **🚀New Feature** \(Enterprise\) Multi-tenancy now works also with JSON groups provider
-* **🐞 Fix** Multi-tenancy \(Enterprise\) incoherent initial kibana\_index and current group
-
-### What's new in 1.16.23
-
-* **🧐Enhancement** Support for Elastic Stack 6.3.1 and 5.6.10
-* **🚀New Feature** \(Enterprise\) Custom CSS injection for Kibana
-* **🚀New Feature** \(Enterprise\) Custom Javascript injection for Kibana
-* **🚀New Feature** \(PRO/Enterprise\) access paths without need to login \(i.e. /api/status\)
-* **🐞Fix** \(PRO/Enterprise\) Navigating to X-Pack APM caused hidden Kibana apps to reappear
-
-### What's new in 1.16.22
-
-* **🚀New Feature:**  map LDAP groups to local groups \(a.k.a. role mapping\)
-* **🐞 Fix** \(Elasticsearch\) wildcard aliases resolution not working in "indices" rule.
-* **🧐Enhancement:** it is now possible now to use JDK 9 and 10
-* **🐞 Fix** \(PRO/Enterprise\) wait forever for login request \(i.e.  slow LDAP servers\)
-* **🐞 Fix** \(PRO/Enterprise\) add spinner and block UI if login request is being sent
-* **🐞 Fix** \(PRO/Enterprise\) if user is logged out because of LDAP cache expiring + slow authentication, redirect to login.
-* **🐞 Fix** \(PRO/Enterprise\) let RO users delete/edit search filters
-
-### What's new in 1.16.21
-
-* **🚀New Feature:** Introducing support for Elasticsearch and Kibana v6.3.0
-* **🐞 Fix** \(Enterprise\) multi tenancy - switching tenancy does not always switch kibana index
-
-### What's new in 1.16.20
-
-## ReadonlyREST PRO/Enterprise for Kibana
-
-* **🧐 Enhancement**: when login, forward "elasticsearch.requestHeadersWhitelist" headers. \(useful for "headers" rule  and "proxy\_auth" to work well.\)
-
-## ReadonlyREST for Elasticsearch
-
-* **🚀New Feature**: DLS \(with dynamic variables suppoort\) Thanks [DataSweet](http://www.datasweet.fr/)!
-* **🚀 New feature**: Field level security
-* **🚀 New rules**: Snapshot, Repositories, Headers
-* **🧐 Enhancement**: custom audit serializers: the request content is available
-* **🐞 Fix** readonlyrest.yml path discovery
-* **🐞 Fix:** LDAP available groups discovery \(tenancy switcher\) corner cases
-* **🐞 Fix**: auth\_key\_sha1, auth\_key\_sha256 hashes in settings should be case insensitive
-* **🐞 Fix**: LDAP authentication didn't work with local group
+* **🚨Security Fix** (ES) [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) & [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) (removed Jackson dependency from ROR core)
+* **🚀New** (ES) [New response\_fields rule](https://forum.readonlyrest.com/t/ror-1-18-9-enterprise-es-7-2-0-enable-cluster-health-without-authentication/1567)
+* **🚀New** (ES) [Support for LDAP server discovery using \_ldaps.\_tcp SRV record](https://forum.readonlyrest.com/t/does-ror-support-dc-locator/1211)
+* **🚀New** (ES) [New configuration option allowing to ignore LDAP connectivity problems](https://forum.readonlyrest.com/t/ror-cannot-start-if-ldap-is-not-available/1748)
+* **🧐Enhancement** (ES) Full support for ILM API
+* **🧐Enhancement** (KBN) Enforce read-after-write consistency between kibana nodes
+* **🧐Enhancement** (KBN ENT) OIDC custom claims incorporated in "assertion" claim
+* **🧐Enhancement** (KBN ENT) OIDC support for configurable kibanaExternalHost (good for Docker)
+* **🧐Enhancement** (KBN ENT) ROR adds "ror-user\_" class to "body" tag for easy per-user CSS/JS
+* **🧐Enhancement** (KBN ENT/PRO) ROR adds "ror-group\_" class to "body" tag for easy per-group CSS/JS
+* **🐞Fix** (ES) [ROR authentication endpoint action](https://forum.readonlyrest.com/t/es-7-4-2-ror-1-18-9-rradmin-refreshsettings-by-block-default/1388)
+* **🐞Fix** (ES) "username" in audit entry when request is rejected ### What's new in 1.25.2
+* **🐞Fix** (ES) [removed verbose logging](https://forum.readonlyrest.com/t/elastic-message-cannot-extract-fields-for-query-after-readonlyrest-installation/1749) ### What's new in 1.25.1
+* **🚨Security Fix** (ES) [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)
+* **🚀New** (ES) 7.10.1 support ### What's new in 1.25.0
+* **🚨Security Fix** (ES) [Common Vulnerabilities and Exposures (CVE)](https://forum.readonlyrest.com/t/update-of-jackson-databind-2-9-6-jar/176)
+* **🚀New** (ES) 7.10.0 support
+* **🚀New** (ES) [auth\_key\_pbkdf2 rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#auth_key_pbkdf2)
+* **🚀New** (ES) [Introduced configuration property defining FLS engine used by fields rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#fields)
+* **🧐Enhancement** (ES) Fields rule performance improvement
+* **🧐Enhancement** (ES) Resolved index API support
+* **🐞Fix** (ES) ["username" in audit entry when user is authenticated via proxy\_auth](https://forum.readonlyrest.com/t/ror-audit-not-logging-user-id)
+* **🐞Fix** (ES) index resolve action should be treated as readonly action
+* **🐞Fix** (ES) /\_snapshot and /\_snapshot/\_all should behave the same ### What's new in 1.24.0
+* **🚨Security Fix** (ES) search template handling fix
+* **🚀New** (ES) 7.9.3 & 6.8.13 support
+* **🧐Enhancement** (ES) full support for ES Snapshots and Restore APIs
+* **🐞Fix** (KBN) fix crash in error handling
+* **🐞Fix** (ES) don't remove ES response warning headers
+* **🐞Fix** (ES) issue when entropy of /dev/random could have been exhausted when using JwtToken rule ### What's new in 1.23.1
+* **🚀New** (ES) 7.9.2 support
+* **🐞Fix** (KBN) fix code 500 error on login in Kibana ### What's new in 1.23.0
+* **🚀New** (ES) introduced must\_involve\_indices option for indices rule
+* **🧐Enhancement** (ES) negation support in headers rules
+* **🧐Enhancement** (ES) [x-pack rollup API handling](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)
+* **🐞Fix** (KBN) deep links query parameters are now handled
+* **🐞Fix** (KBN) make sure default kibana index is always discovered (fixes reporting in 6.x)
+* **🐞Fix** (ES) [settings file permission issue with JDK 1.8.0 25.262-b10](https://forum.readonlyrest.com/t/readonlyrest-for-elastic-wont-start-1-18-8-es6-8-1/1652)
+* **🐞Fix** (ES) /\_cluster/allocation/explain request should not be forbidden if matched block doesn't have indices rules
+* **🐞Fix** (ES) remote address extracting issue
+* **🐞Fix** (ES) [fixed TYP audit field for some request types](https://forum.readonlyrest.com/t/match-wrong-index-in-forbid-block/1653/2) ### What's new in 1.22.1
+* **🐞Fix** (ES) missing handling of aliases API for ES 7.9.0 ### What's new in 1.22.0
+* **🚀New** (ES) 7.9.0 support
+* **🧐Enhancement** (ES) aliases API handling
+* **🧐Enhancement** (ES) dynamic variables support in fields rule
+* **🐞Fix** (ES) [adding aliases issue](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)
+* **🐞Fix** (ES) potential memory leak for ES 7.7.x and above
+* **🐞Fix** (ES) cross cluster search issue fix for X-Pack \_async\_search action
+* **🐞Fix** (ES) XFF entry in audit issue
+* **🐞Fix** (KBN) SAML certificate loading
+* **🐞Fix** (KBN) SAML loading groups from assertion
+* **🐞Fix** (KBN) fix reporting in pre-7.7.0 ### What's new in 1.21.0
+* **🧐Enhancement** (ES) [cluster API support improvements](https://forum.readonlyrest.com/t/settings-problems/1616)
+* **🐞Fix** (ES) X-Pack \_async\_search support
+* **🐞Fix** (ES) \_rollover request handling
+* **🐞Fix** (ES) [handling numeric ssl configuration properties](https://forum.readonlyrest.com/t/numeric-passphrases-invalid-ssl-config/1512)
+* **🐞Fix** (KBN) multitenancy+reporting regression fix (for 7.6.x and earlier)
+* **🐞Fix** (KBN) "x-" headers should be forwarded in /login route when proxy passthrough is enabled
+* **🐞Fix** (unspecified) [(KBN) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)
+* **🐞Fix** (KBN) SAML metadata.xml endpoint not responding
+* **🐞Fix** (KBN) NAT/reverse proxy support for SAML
+* **🐞Fix** (KBN) SAML login redirect error
+* **🐞Fix** (ES) \_readonlyrest/metadata/current\_user should be always allowed by filter/fields rule ### What's new in 1.20.0
+* **🚀New** (unspecified) 7.7.1, 7.8.0 support
+* **🧐Enhancement** (KBN) tidy up audit page
+* **🧐Enhancement** (KBN FREE) clearly inform when features are not available
+* **🧐Enhancement** (KBN) ship license report of libraries
+* **🧐Enhancement** (ES) filter rule performance improvement
+* **🐞Fix** (KBN) proxy\_auth: avoid logout-login loop
+* **🐞Fix** (KBN) 404 error on font CSS file
+* **🐞Fix** (ES) [wildcard in filter query issue](https://forum.readonlyrest.com/t/wildcard-in-dls-filter-gives-error/1551)
+* **🐞Fix** (ES) [forbidden /\_snapshot issue](https://forum.readonlyrest.com/t/get-snapshot-permission-issue/1594)
+* **🐞Fix** (ES) /\_mget handling by indices rule when no index from a list is found
+* **🐞Fix** (ES) available groups order in metadata response should match the order in which groups appear in ACL
+* **🐞Fix** (ES) .readonlyrest and audit index - removed usage of explicit index type
+* **🐞Fix** (ES) [tasks leak bug](https://forum.readonlyrest.com/t/lots-of-active-tasks-in-cat-tasks/1593) ### What's new in 1.19.5
+* **🚀New** (unspecified) 7.7.0, 7.6.2, 6.8.9, 6.8.8 support
+* **🧐Enhancement** (ES/KBN) kibana\_access can be explicitly set to unrestricted
+* **🧐Enhancement** (ES) [LDAP connection pool improvement](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)
+* **🐞Fix** (ES) [better LDAP request timeout handling](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)
+* **🐞Fix** (ES) remote indices searching bug
+* **🐞Fix** (ES) cross cluster search support for \_field\_caps request
+* **🚨Security Fix** (ES) create and delete templates handling
+* **🐞Fix** (KBN) Regression in proxy\_auth\_passthrough
+* **🧐Enhancement** (KBN) whitelistedPaths now accepts basic auth credentials
+* **🧐Enhancement** (KBN) Dump logout button, [new ROR Panel](https://forum.readonlyrest.com/t/new-logout-button-design-new-ror-panel/1476)
+* **🧐Enhancement** (KBN) removed ROR from Kibana sidebar. Admins have a link in new panel.
+* **🧐Enhancement** (KBN) avoid show login form redirecting from SAML IdP
+* **🚀New** (KBN) [OpenID Connect (OIDC) authentication connector](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#openid-connect-oidc)
+* **🚀New** (KBN) [login\_title, login\_subtitle enable 2 column login page](https://forum.readonlyrest.com/t/ror-enterprise-show-support-contact-on-login-page/1508/2)
+* **🚨Security Fix** (KBN) server-side navigation prevention to hidden apps ### What's new in 1.19.4
+* **🐞Fix** (ES) Interpolating config with environment variables in SSL section
+* **🐞Fix** (KBN Ent 6.x) Fixed default space creation in
+* **🐞Fix** (KBN 6.x) Fixed error toast notification not showing
+* **🐞Fix** (KBN Ent) Fixed missing Axios dependency
+* **🐞Fix** (KBN Ent) Fixed SAML connector
+* **🐞Fix** (KBN) Toast notification overlap with logout bar
+* **🧐Enhancement** (KBN) Restyled logout bar
+* **🧐Enhancement** (KBN) Configurable periodic session checker ### What's new in 1.19.3
+* **🚀New** (ES/KBN) 7.6.1 compatibility
+* **🚀New** (ES) customizable name of settings index
+* **🧐Enhancement** (KBN) configurable ROR cookie name
+* **🧐Enhancement** (ES/KBN) handling of encoded ROR headers in Authorization header values
+* **🧐Enhancement** (KBN) user feedback on why login failed
+* **🐞Fix** (ES) support for multiple header values
+* **🐞Fix** (ES) releasing LDAP connection pool on reloading ROR settings
+* **🐞Fix** (KBN) multitenancy issue with 7.6.0+
+* **🐞Fix** (KBN) creation of default space for new tenant
+* **🐞Fix** (KBN 6.x) in RO mode, don't hide add/remove over fields in discovery
+* **🐞Fix** (KBN 6.x) index template & in-index session manager issues ### What's new in 1.19.2
+* **🚀New** (KBN) 7.6.0 support
+* **🧐Enhancement** (KBN) less verbose info logging
+* **🧐Enhancement** (KBN) start up time semantic check for settings
+* **🐞Fix** (KBN Free) missing logout button
+* **🐞Fix** (KBN) error message creating internal proxy
+* **🐞Fix** (KBN 6.x) add field to filter button invisible in RO mode ### What's new in 1.19.1
+* **<unknown>** (KBN) [Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)
+* **🚀New** (ES) 7.6.0 support, Kibana support coming soon
+* **🚀New** (KBN) Audit log dashboard
+* **🚀New** (KBN) Template index can now be declared per tenant instead of globally
+* **🚀New** (ES) custom trust store file and password options in ROR settings
+* **🧐Enhancement** (ES) When "prompt\_for\_basic\_auth" is enabled, ROR is going to return 401 instead of 404 when the index is not found or a user is not allowed to see the index
+* **🧐Enhancement** (ES) literal ipv6 with zone Id is acceptable network address
+* **🧐Enhancement** (ES) LDAP client cache improvements
+* **🐞Fix** (ES) /\_all/\_settings API issue
+* **🐞Fix** (ES) Index stats API & Index shard stores API issue
+* **🐞Fix** (ES) readonlyrest.force\_load\_from\_file setting decoding issue
+* **🐞Fix** (KBN) allowing user to be logged in in two tabs at the same time
+* **🐞Fix** (KBN) logging with JWT parameter issue
+* **🐞Fix** (KBN) parsing of sessions fetched from ES index
+* **🐞Fix** (KBN) logout issue ### What's new in 1.19.0
+* **🚀New** (KBN) Configurable option to delete docs from tenant index when not present in template
+* **🧐Enhancement** (ES) Less verbose logging of blocks history
+* **🧐Enhancement** (ES) Enriched logs and audit with attempted username
+* **🧐Enhancement** (ES) Better settings validation - only one authentication rule can be used in given block
+* **🧐Enhancement** (ES/KBN) Plugin versions printing in logs on launch
+* **🧐Enhancement** (ES) When user doesn't have access to given index, ROR pretends that the index doesn't exist and return 404 instead of 403
+* **🐞Fix** (ES) Searching for nonexistent/forbidden index with wildcard mirrors default ES behaviour instead of returning 403
+* **🐞Fix** (KBN) Switching groups bug ### What's new in 1.18.10
+* **🚀New** (ES/KBN) Support v6.8.6, v7.5.0, v7.5.1
+* **🚀New** (KBN) Group IDs can now be mapped to aliases
+* **🚀New** (ES) New, more robust and simple method of creating custom audit log serializers
+* **🚀New** (ES) Example projects with custom audit log serializers
+* **<unknown>** (KBN) Prevent index migration after kibana startup
+* **🧐Enhancement** (KBN) If default space doesn't exist in kibana index then copy from default one
+* **🧐Enhancement** (KBN) Crypto improvements - store init vector with encrypted data as base64 encoded json.
+* **🧐Enhancement** (ES) Better settings validation - prevent duplicated keys in readonlyrest.yml ### What's new in 1.18.9
+* **🚀New** (ES/KBN) Support v7.4.1, v7.4.2
+* **🚀New** (KBN) Kibana sessions stored in ES index
+* **<unknown>** (ES) issue with in-index settings auto-reloading
+* **<unknown>** (ES) \_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8
+* **🚀New** (ES/KBN) Support v7.4.0
+* **🚀New** (ES) Elasticsearch SQL Support
+* **🚀New** (ES) Internode ssl support for es5x, es60x, es61x and es62x
+* **🚀New** (ES) new runtime variable @{acl:current\_group}
+* **🚀New** (ES) namespace for user variable and support for both versions: @{user} and @{acl:user}
+* **🚀New** (ES) support for multiple values in uri\_re rule
+* **🧐Enhancement** (ES) more reliable in-index settings loading of ES with ROR startup
+* **🧐Enhancement** (ES) less verbose logs in JWT rules
+* **🧐Enhancement** (ES) Better response from ROR API when plugin is disabled
+* **🧐Enhancement** (ES) Splitting verification ssl property to client\_authentication and certificate\_verification
+* **🐞Fix** (ES) issue with backward compatibility of proxy\_auth settings
+* **🐞Fix** (ES) /\_render/template request NPE
+* **🐞Fix** (ES) \_cat/indices API bug fixes
+* **🐞Fix** (ES) \_cat/templates API return empty list instead of FORBIDDEN when no indices are found
+* **🐞Fix** (ES) updated regex for kibana access rule to support 7.3 ES
+* **🐞Fix** (ES) proper resolving of non-string ENV variables in readonlyrest.yml
+* **🐞Fix** (ES) lang-mustache search template handling ### What's new in 1.18.7
+* **🚀New** (ES) Field level security (FLS) supports nested JSON fields
+* **🐞Fix** (ES) Authorization headers appeared in clear in logs
+* **🧐Enhancement** (KBN) Don't logout users when they are not allowed to search a index-pattern
+* **🧐Enhancement** (ES) Headers obfuscation is now case insensitive ### What's new in 1.18.6
+* **🚀New** (ES/KBN) Support v7.3.1, v7.3.2
+* **🚀New** (ES) Configurable header names whose value should be obfuscated in logs
+* **🚀New** (KBN) Dynamic variables from user identity available in custom\_logout\_link
+* **🧐Enhancement** (ES) Richer logs for JWT errors
+* **🧐Enhancement** (ENT) nextUrl works also with SAML now
+* **🧐Enhancement** (ENT) SAML assertion object available in ACL dynamic variables
+* **🧐Enhancement** (KBN) Validate LDAP server(s) before accepting new YAML settings
+* **🧐Enhancement** (KBN) Ensure a read-only UX for 'ro' users in older Kibana
+* **🐞Fix** (ES) Fix memory leak from dependency (snakeYAML) ### What's new in 1.18.5
+* **🐞Fix** (ES) indices rule can now properly handle also the templates API
+* **🧐Enhancement** (ES) Array dynamic variables are serialized as CSV wrapped in double quotes
+* **🧐Enhancement** (ES) Cleaner debug logs (no stacktraces on forbidden requests)
+* **🧐Enhancement** (ES) LDAP debug logs fire also when cache is hit
+* **🚀New** (ES/KBN) Support v7.2.1, v7.3.0
+* **🐞Fix** (PRO) PRO plugin crashing for some Kibana versions
+* **🐞Fix** (ENT) SAML library wrote a too large cookie sometimes
+* **🐞Fix** (ENT) SAML logout not working
+* **🐞Fix** (ENT) JWT fix exception "cannot set requestHeadersWhitelist"
+* **🐞Fix** (PRO/ENT) Hide more UI elements for RO users
+* **🐞Fix** (PRO/ENT) Sometimes not all the available groups appear in tenancy selector
+* **🐞Fix** (PRO/ENT) Feature "nextUrl" broke
+* **🐞Fix** (PRO/ENT) prevent user kick-out when APM is not configured and you are not an admin
+* **🚀New** (PRO/ENT) Kibana request path/method now sent to ES (good for policing dev-tools) ### What's new in 1.18.4
+* **🚀New** (ES) User impersonation API
+* **🚀New** (ES) Support latest 6.x and 5.x versions
+* **🐞Fix** (ES) filter/fields rules leak
+* **🐞Fix** (KBN/ENT) allow more action for kibana\_access, prevent sudden logout
+* **🐞Fix** (KBN/ENT) temporarily roll back "support for unlimited tenancies" ### What's new in 1.18.3
+* **🚀New** (unspecified) Support added for ES/Kibana 6.8.1
+* **🧐Enhancement** (ES) Crash ES on invalid settings instead of stalling forever
+* **🧐Enhancement** (ES) Better logging on JWT, JSON-paths, LDAP, YAML errors
+* **🧐Enhancement** (ES) Block level settings validation to user with precious hints
+* **🧐Enhancement** (ES) If force\_load\_from\_file: true, don't poll index settings
+* **🧐Enhancement** (ES) Order now counts declaring LDAP Failover HA servers
+* **🐞Fix** (ES) "EsIndexJsonContentProvider" had a null pointer exception
+* **🐞Fix** (ES) "es.set.netty.runtime.available.processors" exception
+* **🧐Enhancement** (KBN) Collapsible logout button
+* **🧐Enhancement** (KBN) ROR App now uses a HA http client
+* **🧐Enhancement** (KBN) Automatic logout for inactivity
+* **🧐Enhancement** (KBN) Support unlimited amount of tenancies
+* **🐞Fix** (KBN/ENT) concurrent multitenancy bug
+* **🐞Fix** (KBN) Avoid sporadic errors on Save/Load buttons ### What's new in 1.18.2
+* **🚀New** (unspecified) Support for Elasticsearch & Kibana 7.2.0
+* **🐞Fix** (ES) restore indices ("IDX") in audit logging
+* **🧐Enhancement** (ES) New algorithm of setting evaluation order
+* **🚀New** (ES) JWT claims as dynamic variables. I.e. "@{jwt:claim.json.path}"
+* **🚀New** (ES) "explode" dynamic variables. I.e. indices: \["@explode{x-indices}"\]
+* **🐞Fix** (PRO/Enterprise) preserve comments and formatting in YAML editor
+* **🐞Fix** (PRO/Enterprise) Print error message when session is expired
+* **🐞Fix** (PRO/Enterprise) Redirect to original link after login
+* **🐞Fix** (PRO/Enterprise) Broken CSV reporting
+* **🧐Enhancement** (PRO/Enterprise) Prevent navigating away from YAML editor w/ unsaved changes
+* **🐞Fix** (Enterprise) Exception when SAML connectors were all disabled
+* **🐞Fix** (Enterprise) Concurrent tenants could mix up each other kibana index
+* **🐞Fix** (Enterprise) Cannot inject custom JS if no custom CSS was also declared
+* **🐞Fix** (Enterprise) Injected JS had no effect on ROR logout button
+* **🐞Fix** (Enterprise) On narrow screens, the YAML editor showed buttons twice ### What's new in 1.18.1
+* **🐞Fix** (Elasticsearch) Reindex requests failed for a regression in indices extraction
+* **🐞Fix** (Elasticsearch) Groups rule erratically failed
+* **🐞Fix** (Elasticsearch) JWT claims can now contain special characters
+* **🧐Enhancement** (Elasticsearch) Better ACL History logging
+* **🧐Enhancement** (Elasticsearch) QueryLogSerializer and old custom log serializers work again
+* **🐞Fix** (PRO/Enterprise) ReadonlyREST icon in Kibana was white on white
+* **🐞Fix** (Enterprise) SAML connectors could not be disabled
+* **🐞Fix** (Enterprise) SAML connector "buttonName" didn't work ### What's new in 1.18.0
+* **🚀New** (unspecified) Support for Elasticsearch & Kibana 7.0.1
+* **🧐Enhancement** (Elasticsearch) empty array values in settings are invalid
+* **🐞Fix** (Elasticsearch) arbitrary x-cluster search referencing local cluster
+* **🐞Fix** (Elasticsearch) ArrayOutOfBoundException on snapshot operations
+* **🧐Enhancement** (PRO/Enterprise) History cleaning can now be disabled ("clearSessionOnEvents") ### What's new in 1.17.7
+* **🚀New** (unspecified) Support for Elasticsearch 7.0.0 (Kibana is coming soon)
+* **🧐Enhancement** (Elasticsearch) rewritten LDAP connector
+* **🧐Enhancement** (Elasticsearch) new core written in Scala is now GA
+* **🐞Fix** (Enterprise) devtools requests now honor the currently selected tenancy
+* **🐞Fix** (Enterprise/PRO) Fix "connectorsService" error in installation ### What's new in 1.17.5
+* **🚀New** (unspecified) Support for Kibana/Elasticsearch 6.7.1
+* **🧐Enhancement** (Enterprise &gt;= Kibana 6.6.0) Multiple SAML identity provider
+* **🐞Fix** (Enterprise/PRO) Don't pass auth headers back to the browser
+* **🐞Fix** (Enterprise/PRO) Missing null check caused error in reporting (CSV)
+* **🐞Fix** (Enterprise) Don't reject requests if SAML groups are not configured
+* **🐞Fix** (unspecified) filter/fields rules not working in msearch (in 6.7.x)
+* **🧐Enhancement** (unspecified) Print whole LDAP search query in debug log ### What's new in 1.17.4
+* **🚀New** (unspecified) Support for Kibana/Elasticsearch 6.7.0
+* **🧐Enhancement** (PRO/Enterprise) JWT query param is the preferred credentials provider
+* **🧐Enhancement** (PRO/Enterprise) admin users can use indices management
+* **🧐Enhancement** (PRO/Enterprise) ro users can dismiss telemetry form
+* **🐞Fix** (unspecified) Audit logging in 5.1.x now works again
+* **🐞Fix** (unspecified) unpredictable behaviour of "filter" and "fields" when using external auth
+* **🐞Fix** (unspecified) LDAP ConcurrentModificationException
+* **🐞Fix** (unspecified) Audit logging in 5.1.x now works again
+* **🐞Fix** (PRO/Enterprise) JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly
+* **🐞Fix** (Enterprise) Tenancy selector showing if user belonged to one group
+* **🐞Fix** (PRO/Enterprise) RW buttons not hiding for RO users in React Kibana apps
+* **🐞Fix** (Enterprise) Tenancy templating now works much more reliably
+* **🐞Fix** (Enterprise) Missing tenancy selector icon after switching tenancy
+* **🐞Fix** (PRO/Enterprise) barring static files requests caused sudden logout
+* **🐞Fix** (unspecified) Numerous fixes to better support Kibana 6.6.x
+* **🐞Fix** (unspecified) Critical fixes in new Scala core
+* **🐞Fix** (unspecified) Exception in reindex requests caused tenancy templating to fail
+* **🧐Enhancement** (unspecified) Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1
+* **🐞Fix** (PRO/Enterprise) SAML now works well in 6.6.x
+* **🐞Fix** (PRO/Enterprise) "undefined" authentication error before login
+* **🐞Fix** (Enterprise) Default space creation failures for new tenants
+* **🐞Fix** (Enterprise) Icons/titles CSS misalignment in sidebar (Firefox)
+* **🧐Enhancement** (Enterprise) UX: Larger tenancy selector
+* **🐞Fix** (Enterprise) Privilege escalation when changing tenancies under monitoring
+* **🐞Fix** (Elasticsearch) compatibility fixes to support new Kibana features
+* **🧐Enhancement** (Elasticsearch) New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0
+* **🚀New** (unspecified) Support for Kibana/Elasticsearch 6.6.0, 6.6.1
+* **🚀New** (unspecified) Internode SSL (ES 6.3.x onwards)
+* **🧐Enhancement** (PRO/Enterprise) UI appearence
+* **🧐Enhancement** (unspecified) Made HTTP Connection configurable (PR \#410)
+* **🐞Fix** (unspecified) slow boot due to SecureRandom waiting for sufficient entropy
+* **🐞Fix** (unspecified) Enable kibana\_access:ro to create short urls in es6.3+ (PR \#408) ### What's new in 1.16.34
+* **🧐Enhancement** (unspecified) X-Forwarded-For header in printed es logs ("XFF")
+* **🧐Enhancement** (unspecified) kibana_index: ".kibana_@{user}" when user is "John Doe" becomes .kibana\_john\_doe
+* **🐞Fix** (Enteprise) parse SAML groups from assertion as array of strings
+* **🐞Fix** (Enteprise) SAMLRequest in location header was URLEncoded twice, broke on some IdP
+* **🐞Fix** (PRO/Enteprise) "cookiePass" works again, no more need for sticky cookies in load balancers!
+* **🐞Fix** (PRO/Enteprise) fix redirect loop with JWT deep linking when JWT token expires
+* **🧐Enhancement** (PRO/Enteprise) fix audit demo page CSS
+* **🧐Enhancement** (Enteprise) SAML more configuration parameters available
+* **🚀New** (PRO/Enteprise) set ROR to debug mode (readonlyrest\_kbn.logLevel: "debug") ### What's new in 1.16.33
+* **🐞Fix** (PRO/Enteprise) compatibility problems with older Kibana versions
+* **🐞Fix** (PRO/Enteprise) compatibility problems with OSS Kibana version ### What's new in 1.16.32
+* **🚀New** (unspecified) "kibanaIndexTemplate": default dashboards and spaces for new tenants
+* **🧐Enhancement** (unspecified) Support for ES/Kibana 6.5.4
+* **🧐Enhancement** (unspecified) Upgraded LDAP library
+* **🧐Enhancement** (Enterprise) Now tenants save their CSV exports in their own reporting index
+* **🐞Fix** (PRO/Enteprise) Support passwords that start and/or end with spaces
+* **🐞Fix** (PRO/Enterprise) Now reporting works again ### What's new in 1.16.31
+* **🧐Enhancement** (unspecified) Support for ES/Kibana 6.5.2, 6.5.3
+* **<unknown>** (unspecified) : Laid out the foundation for LDAP HA support ### What's new in 1.16.29
+* **🧐Enhancement** (unspecified) Support for ES/Kibana 6.4.3
+* **🚀New** (PRO/Enterprise) configurable server side session duration
+* **🚀New** (unspecified) \[LDAP\] High Availability: Round Robin or Failover ### What's new in 1.16.28
+* **🧐Enhancement** (unspecified) Support for ES/Kibana 6.4.2
+* **🐞Fix** (Enterprise) Multi tenancy: sometimes changing tenancy would not change kibana index
+* **🐞Fix** (Enterprise/PRO) Avoid echoing Base64 encoded credentials in login form error message
+* **🧐Enhancement** (Enterprise/PRO) Remove latest search/visualization/dashboard history on logout
+* **🧐Enhancement** (Enterprise/PRO) Clear transient authentication cookies on login error to avoid authentication deadlocks
+* **🐞Fix** (unspecified) : External JWT verification may throw ArrayOutOfBoundException
+* **<unknown>** (unspecified) : Laid out the foundation for internode SSL transport (port 9300) ### What's new in 1.16.27
+* **🚀New** (unspecified) \[JWT\] external validator: it's now possible to avoid storing the private key in settings
+* **🧐Enhancement** (unspecified) Support for ES/Kibana 6.4.1
+* **🧐Enhancement** (unspecified) Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)
+* **🧐Enhancement** (unspecified) SAML Single log out flow
+* **🐞Fix** (Enterprise/PRO) [cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB.
+* **🧐Enhancement** (Enterprise/PRO) much faster logout ### What's new in 1.16.26
+* **🐞Fix** (PRO/Enterprise) bugs during plugin packaging and installation process ### What's new in 1.16.25
+* **🚀New** (unspecified) Users rule: easily restrict external authentication to a list of users
+* **🧐Enhancement** (unspecified) Support for ES 5.6.11
+* **🐞Fix** (Enterprise/PRO) Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24
+* **🚀New** (Enterprise) SAML Authentication
+* **🚀New** (unspecified) Support for Elasticsearch and Kibana 6.4.0
+* **🚀New** (unspecified) Headers rule now split in headers\_or and headers\_and
+* **🧐Enhancement** (unspecified) Headers rule now allows wildcards
+* **🚀New** (Enterprise) Multi-tenancy now works also with JSON groups provider
+* **🐞Fix** (unspecified) Multi-tenancy (Enterprise) incoherent initial kibana\_index and current group ### What's new in 1.16.23
+* **🧐Enhancement** (unspecified) Support for Elastic Stack 6.3.1 and 5.6.10
+* **🚀New** (Enterprise) Custom CSS injection for Kibana
+* **🚀New** (Enterprise) Custom Javascript injection for Kibana
+* **🚀New** (PRO/Enterprise) access paths without need to login (i.e. /api/status)
+* **🐞Fix** (PRO/Enterprise) Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22
+* **🚀New** (unspecified) map LDAP groups to local groups (a.k.a. role mapping)
+* **🐞Fix** (Elasticsearch) wildcard aliases resolution not working in "indices" rule.
+* **🧐Enhancement** (unspecified) it is now possible now to use JDK 9 and 10
+* **🐞Fix** (PRO/Enterprise) wait forever for login request (i.e.  slow LDAP servers)
+* **🐞Fix** (PRO/Enterprise) add spinner and block UI if login request is being sent
+* **🐞Fix** (PRO/Enterprise) if user is logged out because of LDAP cache expiring + slow authentication, redirect to login.
+* **🐞Fix** (PRO/Enterprise) let RO users delete/edit search filters ### What's new in 1.16.21
+* **🚀New** (unspecified) Introducing support for Elasticsearch and Kibana v6.3.0
+* **🐞Fix** (Enterprise) multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana
+* **🧐Enhancement** (unspecified) : when login, forward "elasticsearch.requestHeadersWhitelist" headers. (useful for "headers" rule  and "proxy\_auth" to work well.) ## ReadonlyREST for Elasticsearch
+* **🚀New** (unspecified) : DLS (with dynamic variables suppoort) Thanks [DataSweet](http://www.datasweet.fr/)!
+* **🚀New** (unspecified) : Field level security
+* **🚀New** (unspecified) : Snapshot, Repositories, Headers
+* **🧐Enhancement** (unspecified) : custom audit serializers: the request content is available
+* **🐞Fix** (unspecified) readonlyrest.yml path discovery
+* **🐞Fix** (unspecified) LDAP available groups discovery (tenancy switcher) corner cases
+* **🐞Fix** (unspecified) : auth\_key\_sha1, auth\_key\_sha256 hashes in settings should be case insensitive
+* **🐞Fix** (unspecified) : LDAP authentication didn't work with local group
 

--- a/changelog/1.26.0.yaml
+++ b/changelog/1.26.0.yaml
@@ -1,3 +1,1587 @@
 version: "1.26.0"
 release_date: "2021-01-02"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) & [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) (removed Jackson dependency from ROR core)"
+  - type: new
+    components: [es]
+    text: "[New response\\_fields rule](https://forum.readonlyrest.com/t/ror-1-18-9-enterprise-es-7-2-0-enable-cluster-health-without-authentication/1567)"
+  - type: new
+    components: [es]
+    text: "[Support for LDAP server discovery using \\_ldaps.\\_tcp SRV record](https://forum.readonlyrest.com/t/does-ror-support-dc-locator/1211)"
+  - type: new
+    components: [es]
+    text: "[New configuration option allowing to ignore LDAP connectivity problems](https://forum.readonlyrest.com/t/ror-cannot-start-if-ldap-is-not-available/1748)"
+  - type: enhancement
+    components: [es]
+    text: "Full support for ILM API"
+  - type: enhancement
+    components: [kbn]
+    text: "Enforce read-after-write consistency between kibana nodes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) OIDC custom claims incorporated in \"assertion\" claim"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "OIDC custom claims incorporated in \"assertion\" claim"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) OIDC support for configurable kibanaExternalHost \\(good for Docker\\)"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "OIDC support for configurable kibanaExternalHost (good for Docker)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🧐Enhancement** \\(KBN ENT\\) ROR adds \"ror-user\\_\" class to \"body\" tag for easy per-user CSS/JS"
+    type: enhancement
+    components_raw: "KBN ENT"
+    text: "ROR adds \"ror-user\\_\" class to \"body\" tag for easy per-user CSS/JS"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent,pro
+    # original: "* **🧐Enhancement** \\(KBN ENT/PRO\\) ROR adds \"ror-group\\_\" class to \"body\" tag for easy per-group CSS/JS"
+    type: enhancement
+    components_raw: "KBN ENT/PRO"
+    text: "ROR adds \"ror-group\\_\" class to \"body\" tag for easy per-group CSS/JS"
+  - type: fix
+    components: [es]
+    text: "[ROR authentication endpoint action](https://forum.readonlyrest.com/t/es-7-4-2-ror-1-18-9-rradmin-refreshsettings-by-block-default/1388)"
+  - type: fix
+    components: [es]
+    text: "\"username\" in audit entry when request is rejected ### What's new in 1.25.2"
+  - type: fix
+    components: [es]
+    text: "[removed verbose logging](https://forum.readonlyrest.com/t/elastic-message-cannot-extract-fields-for-query-after-readonlyrest-installation/1749) ### What's new in 1.25.1"
+  - type: security
+    components: [es]
+    text: "[CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)"
+  - type: new
+    components: [es]
+    text: "7.10.1 support ### What's new in 1.25.0"
+  - type: security
+    components: [es]
+    text: "[Common Vulnerabilities and Exposures (CVE)](https://forum.readonlyrest.com/t/update-of-jackson-databind-2-9-6-jar/176)"
+  - type: new
+    components: [es]
+    text: "7.10.0 support"
+  - type: new
+    components: [es]
+    text: "[auth\\_key\\_pbkdf2 rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#auth_key_pbkdf2)"
+  - type: new
+    components: [es]
+    text: "[Introduced configuration property defining FLS engine used by fields rule](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.25.x/elasticsearch.md#fields)"
+  - type: enhancement
+    components: [es]
+    text: "Fields rule performance improvement"
+  - type: enhancement
+    components: [es]
+    text: "Resolved index API support"
+  - type: fix
+    components: [es]
+    text: "[\"username\" in audit entry when user is authenticated via proxy\\_auth](https://forum.readonlyrest.com/t/ror-audit-not-logging-user-id)"
+  - type: fix
+    components: [es]
+    text: "index resolve action should be treated as readonly action"
+  - type: fix
+    components: [es]
+    text: "/\\_snapshot and /\\_snapshot/\\_all should behave the same ### What's new in 1.24.0"
+  - type: security
+    components: [es]
+    text: "search template handling fix"
+  - type: new
+    components: [es]
+    text: "7.9.3 & 6.8.13 support"
+  - type: enhancement
+    components: [es]
+    text: "full support for ES Snapshots and Restore APIs"
+  - type: fix
+    components: [kbn]
+    text: "fix crash in error handling"
+  - type: fix
+    components: [es]
+    text: "don't remove ES response warning headers"
+  - type: fix
+    components: [es]
+    text: "issue when entropy of /dev/random could have been exhausted when using JwtToken rule ### What's new in 1.23.1"
+  - type: new
+    components: [es]
+    text: "7.9.2 support"
+  - type: fix
+    components: [kbn]
+    text: "fix code 500 error on login in Kibana ### What's new in 1.23.0"
+  - type: new
+    components: [es]
+    text: "introduced must\\_involve\\_indices option for indices rule"
+  - type: enhancement
+    components: [es]
+    text: "negation support in headers rules"
+  - type: enhancement
+    components: [es]
+    text: "[x-pack rollup API handling](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)"
+  - type: fix
+    components: [kbn]
+    text: "deep links query parameters are now handled"
+  - type: fix
+    components: [kbn]
+    text: "make sure default kibana index is always discovered (fixes reporting in 6.x)"
+  - type: fix
+    components: [es]
+    text: "[settings file permission issue with JDK 1.8.0 25.262-b10](https://forum.readonlyrest.com/t/readonlyrest-for-elastic-wont-start-1-18-8-es6-8-1/1652)"
+  - type: fix
+    components: [es]
+    text: "/\\_cluster/allocation/explain request should not be forbidden if matched block doesn't have indices rules"
+  - type: fix
+    components: [es]
+    text: "remote address extracting issue"
+  - type: fix
+    components: [es]
+    text: "[fixed TYP audit field for some request types](https://forum.readonlyrest.com/t/match-wrong-index-in-forbid-block/1653/2) ### What's new in 1.22.1"
+  - type: fix
+    components: [es]
+    text: "missing handling of aliases API for ES 7.9.0 ### What's new in 1.22.0"
+  - type: new
+    components: [es]
+    text: "7.9.0 support"
+  - type: enhancement
+    components: [es]
+    text: "aliases API handling"
+  - type: enhancement
+    components: [es]
+    text: "dynamic variables support in fields rule"
+  - type: fix
+    components: [es]
+    text: "[adding aliases issue](https://forum.readonlyrest.com/t/actions-still-forbidden-to-unrestricted-user/1659)"
+  - type: fix
+    components: [es]
+    text: "potential memory leak for ES 7.7.x and above"
+  - type: fix
+    components: [es]
+    text: "cross cluster search issue fix for X-Pack \\_async\\_search action"
+  - type: fix
+    components: [es]
+    text: "XFF entry in audit issue"
+  - type: fix
+    components: [kbn]
+    text: "SAML certificate loading"
+  - type: fix
+    components: [kbn]
+    text: "SAML loading groups from assertion"
+  - type: fix
+    components: [kbn]
+    text: "fix reporting in pre-7.7.0 ### What's new in 1.21.0"
+  - type: enhancement
+    components: [es]
+    text: "[cluster API support improvements](https://forum.readonlyrest.com/t/settings-problems/1616)"
+  - type: fix
+    components: [es]
+    text: "X-Pack \\_async\\_search support"
+  - type: fix
+    components: [es]
+    text: "\\_rollover request handling"
+  - type: fix
+    components: [es]
+    text: "[handling numeric ssl configuration properties](https://forum.readonlyrest.com/t/numeric-passphrases-invalid-ssl-config/1512)"
+  - type: fix
+    components: [kbn]
+    text: "multitenancy+reporting regression fix (for 7.6.x and earlier)"
+  - type: fix
+    components: [kbn]
+    text: "\"x-\" headers should be forwarded in /login route when proxy passthrough is enabled"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** [\\(KBN\\) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)"
+    type: fix
+    components_raw: "unspecified"
+    text: "[(KBN) Logout now redirects to login screen when using proxy](https://forum.readonlyrest.com/t/kibana-ror-1-19-5-issue/1576/24)"
+  - type: fix
+    components: [kbn]
+    text: "SAML metadata.xml endpoint not responding"
+  - type: fix
+    components: [kbn]
+    text: "NAT/reverse proxy support for SAML"
+  - type: fix
+    components: [kbn]
+    text: "SAML login redirect error"
+  - type: fix
+    components: [es]
+    text: "\\_readonlyrest/metadata/current\\_user should be always allowed by filter/fields rule ### What's new in 1.20.0"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** 7.7.1, 7.8.0 support"
+    type: new
+    components_raw: "unspecified"
+    text: "7.7.1, 7.8.0 support"
+  - type: enhancement
+    components: [kbn]
+    text: "tidy up audit page"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn free
+    # original: "* **🧐Enhancement** \\(KBN FREE\\) clearly inform when features are not available"
+    type: enhancement
+    components_raw: "KBN FREE"
+    text: "clearly inform when features are not available"
+  - type: enhancement
+    components: [kbn]
+    text: "ship license report of libraries"
+  - type: enhancement
+    components: [es]
+    text: "filter rule performance improvement"
+  - type: fix
+    components: [kbn]
+    text: "proxy\\_auth: avoid logout-login loop"
+  - type: fix
+    components: [kbn]
+    text: "404 error on font CSS file"
+  - type: fix
+    components: [es]
+    text: "[wildcard in filter query issue](https://forum.readonlyrest.com/t/wildcard-in-dls-filter-gives-error/1551)"
+  - type: fix
+    components: [es]
+    text: "[forbidden /\\_snapshot issue](https://forum.readonlyrest.com/t/get-snapshot-permission-issue/1594)"
+  - type: fix
+    components: [es]
+    text: "/\\_mget handling by indices rule when no index from a list is found"
+  - type: fix
+    components: [es]
+    text: "available groups order in metadata response should match the order in which groups appear in ACL"
+  - type: fix
+    components: [es]
+    text: ".readonlyrest and audit index - removed usage of explicit index type"
+  - type: fix
+    components: [es]
+    text: "[tasks leak bug](https://forum.readonlyrest.com/t/lots-of-active-tasks-in-cat-tasks/1593) ### What's new in 1.19.5"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** 7.7.0, 7.6.2, 6.8.9, 6.8.8 support"
+    type: new
+    components_raw: "unspecified"
+    text: "7.7.0, 7.6.2, 6.8.9, 6.8.8 support"
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "kibana\\_access can be explicitly set to unrestricted"
+  - type: enhancement
+    components: [es]
+    text: "[LDAP connection pool improvement](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)"
+  - type: fix
+    components: [es]
+    text: "[better LDAP request timeout handling](https://forum.readonlyrest.com/t/losing-connections-to-ldap-servers/1485)"
+  - type: fix
+    components: [es]
+    text: "remote indices searching bug"
+  - type: fix
+    components: [es]
+    text: "cross cluster search support for \\_field\\_caps request"
+  - type: security
+    components: [es]
+    text: "create and delete templates handling"
+  - type: fix
+    components: [kbn]
+    text: "Regression in proxy\\_auth\\_passthrough"
+  - type: enhancement
+    components: [kbn]
+    text: "whitelistedPaths now accepts basic auth credentials"
+  - type: enhancement
+    components: [kbn]
+    text: "Dump logout button, [new ROR Panel](https://forum.readonlyrest.com/t/new-logout-button-design-new-ror-panel/1476)"
+  - type: enhancement
+    components: [kbn]
+    text: "removed ROR from Kibana sidebar. Admins have a link in new panel."
+  - type: enhancement
+    components: [kbn]
+    text: "avoid show login form redirecting from SAML IdP"
+  - type: new
+    components: [kbn]
+    text: "[OpenID Connect (OIDC) authentication connector](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#openid-connect-oidc)"
+  - type: new
+    components: [kbn]
+    text: "[login\\_title, login\\_subtitle enable 2 column login page](https://forum.readonlyrest.com/t/ror-enterprise-show-support-contact-on-login-page/1508/2)"
+  - type: security
+    components: [kbn]
+    text: "server-side navigation prevention to hidden apps ### What's new in 1.19.4"
+  - type: fix
+    components: [es]
+    text: "Interpolating config with environment variables in SSL section"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent 6.x
+    # original: "* **🐞Fix** \\(KBN Ent 6.x\\) Fixed default space creation in"
+    type: fix
+    components_raw: "KBN Ent 6.x"
+    text: "Fixed default space creation in"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) Fixed error toast notification not showing"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "Fixed error toast notification not showing"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🐞Fix** \\(KBN Ent\\) Fixed missing Axios dependency"
+    type: fix
+    components_raw: "KBN Ent"
+    text: "Fixed missing Axios dependency"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn ent
+    # original: "* **🐞Fix** \\(KBN Ent\\) Fixed SAML connector"
+    type: fix
+    components_raw: "KBN Ent"
+    text: "Fixed SAML connector"
+  - type: fix
+    components: [kbn]
+    text: "Toast notification overlap with logout bar"
+  - type: enhancement
+    components: [kbn]
+    text: "Restyled logout bar"
+  - type: enhancement
+    components: [kbn]
+    text: "Configurable periodic session checker ### What's new in 1.19.3"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "7.6.1 compatibility"
+  - type: new
+    components: [es]
+    text: "customizable name of settings index"
+  - type: enhancement
+    components: [kbn]
+    text: "configurable ROR cookie name"
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "handling of encoded ROR headers in Authorization header values"
+  - type: enhancement
+    components: [kbn]
+    text: "user feedback on why login failed"
+  - type: fix
+    components: [es]
+    text: "support for multiple header values"
+  - type: fix
+    components: [es]
+    text: "releasing LDAP connection pool on reloading ROR settings"
+  - type: fix
+    components: [kbn]
+    text: "multitenancy issue with 7.6.0+"
+  - type: fix
+    components: [kbn]
+    text: "creation of default space for new tenant"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) in RO mode, don't hide add/remove over fields in discovery"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "in RO mode, don't hide add/remove over fields in discovery"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) index template & in-index session manager issues ### What's new in 1.19.2"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "index template & in-index session manager issues ### What's new in 1.19.2"
+  - type: new
+    components: [kbn]
+    text: "7.6.0 support"
+  - type: enhancement
+    components: [kbn]
+    text: "less verbose info logging"
+  - type: enhancement
+    components: [kbn]
+    text: "start up time semantic check for settings"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn free
+    # original: "* **🐞Fix** \\(KBN Free\\) missing logout button"
+    type: fix
+    components_raw: "KBN Free"
+    text: "missing logout button"
+  - type: fix
+    components: [kbn]
+    text: "error message creating internal proxy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn 6.x
+    # original: "* **🐞Fix** \\(KBN 6.x\\) add field to filter button invisible in RO mode ### What's new in 1.19.1"
+    type: fix
+    components_raw: "KBN 6.x"
+    text: "add field to filter button invisible in RO mode ### What's new in 1.19.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* **🎁Product** \\(KBN\\) [Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)"
+    type: <unknown>
+    components_raw: "KBN"
+    text: "[Launched ReadonlyREST Free for Kibana!](https://forum.readonlyrest.com/t/provide-kibana-login-page-for-ror-oss-version/1441/2?u=sscarduzio)"
+  - type: new
+    components: [es]
+    text: "7.6.0 support, Kibana support coming soon"
+  - type: new
+    components: [kbn]
+    text: "Audit log dashboard"
+  - type: new
+    components: [kbn]
+    text: "Template index can now be declared per tenant instead of globally"
+  - type: new
+    components: [es]
+    text: "custom trust store file and password options in ROR settings"
+  - type: enhancement
+    components: [es]
+    text: "When \"prompt\\_for\\_basic\\_auth\" is enabled, ROR is going to return 401 instead of 404 when the index is not found or a user is not allowed to see the index"
+  - type: enhancement
+    components: [es]
+    text: "literal ipv6 with zone Id is acceptable network address"
+  - type: enhancement
+    components: [es]
+    text: "LDAP client cache improvements"
+  - type: fix
+    components: [es]
+    text: "/\\_all/\\_settings API issue"
+  - type: fix
+    components: [es]
+    text: "Index stats API & Index shard stores API issue"
+  - type: fix
+    components: [es]
+    text: "readonlyrest.force\\_load\\_from\\_file setting decoding issue"
+  - type: fix
+    components: [kbn]
+    text: "allowing user to be logged in in two tabs at the same time"
+  - type: fix
+    components: [kbn]
+    text: "logging with JWT parameter issue"
+  - type: fix
+    components: [kbn]
+    text: "parsing of sessions fetched from ES index"
+  - type: fix
+    components: [kbn]
+    text: "logout issue ### What's new in 1.19.0"
+  - type: new
+    components: [kbn]
+    text: "Configurable option to delete docs from tenant index when not present in template"
+  - type: enhancement
+    components: [es]
+    text: "Less verbose logging of blocks history"
+  - type: enhancement
+    components: [es]
+    text: "Enriched logs and audit with attempted username"
+  - type: enhancement
+    components: [es]
+    text: "Better settings validation - only one authentication rule can be used in given block"
+  - type: enhancement
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Plugin versions printing in logs on launch"
+  - type: enhancement
+    components: [es]
+    text: "When user doesn't have access to given index, ROR pretends that the index doesn't exist and return 404 instead of 403"
+  - type: fix
+    components: [es]
+    text: "Searching for nonexistent/forbidden index with wildcard mirrors default ES behaviour instead of returning 403"
+  - type: fix
+    components: [kbn]
+    text: "Switching groups bug ### What's new in 1.18.10"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v6.8.6, v7.5.0, v7.5.1"
+  - type: new
+    components: [kbn]
+    text: "Group IDs can now be mapped to aliases"
+  - type: new
+    components: [es]
+    text: "New, more robust and simple method of creating custom audit log serializers"
+  - type: new
+    components: [es]
+    text: "Example projects with custom audit log serializers"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* 🐞**Fix** \\(KBN\\) Prevent index migration after kibana startup"
+    type: <unknown>
+    components_raw: "KBN"
+    text: "Prevent index migration after kibana startup"
+  - type: enhancement
+    components: [kbn]
+    text: "If default space doesn't exist in kibana index then copy from default one"
+  - type: enhancement
+    components: [kbn]
+    text: "Crypto improvements - store init vector with encrypted data as base64 encoded json."
+  - type: enhancement
+    components: [es]
+    text: "Better settings validation - prevent duplicated keys in readonlyrest.yml ### What's new in 1.18.9"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.4.1, v7.4.2"
+  - type: new
+    components: [kbn]
+    text: "Kibana sessions stored in ES index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* 🐞**Fix** \\(ES\\) issue with in-index settings auto-reloading"
+    type: <unknown>
+    components_raw: "ES"
+    text: "issue with in-index settings auto-reloading"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* 🐞**Fix** \\(ES\\) \\_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8"
+    type: <unknown>
+    components_raw: "ES"
+    text: "\\_cat/indices empty response when matched block doesn't contain 'indices' rule ### What's new in 1.18.8"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.4.0"
+  - type: new
+    components: [es]
+    text: "Elasticsearch SQL Support"
+  - type: new
+    components: [es]
+    text: "Internode ssl support for es5x, es60x, es61x and es62x"
+  - type: new
+    components: [es]
+    text: "new runtime variable @{acl:current\\_group}"
+  - type: new
+    components: [es]
+    text: "namespace for user variable and support for both versions: @{user} and @{acl:user}"
+  - type: new
+    components: [es]
+    text: "support for multiple values in uri\\_re rule"
+  - type: enhancement
+    components: [es]
+    text: "more reliable in-index settings loading of ES with ROR startup"
+  - type: enhancement
+    components: [es]
+    text: "less verbose logs in JWT rules"
+  - type: enhancement
+    components: [es]
+    text: "Better response from ROR API when plugin is disabled"
+  - type: enhancement
+    components: [es]
+    text: "Splitting verification ssl property to client\\_authentication and certificate\\_verification"
+  - type: fix
+    components: [es]
+    text: "issue with backward compatibility of proxy\\_auth settings"
+  - type: fix
+    components: [es]
+    text: "/\\_render/template request NPE"
+  - type: fix
+    components: [es]
+    text: "\\_cat/indices API bug fixes"
+  - type: fix
+    components: [es]
+    text: "\\_cat/templates API return empty list instead of FORBIDDEN when no indices are found"
+  - type: fix
+    components: [es]
+    text: "updated regex for kibana access rule to support 7.3 ES"
+  - type: fix
+    components: [es]
+    text: "proper resolving of non-string ENV variables in readonlyrest.yml"
+  - type: fix
+    components: [es]
+    text: "lang-mustache search template handling ### What's new in 1.18.7"
+  - type: new
+    components: [es]
+    text: "Field level security (FLS) supports nested JSON fields"
+  - type: fix
+    components: [es]
+    text: "Authorization headers appeared in clear in logs"
+  - type: enhancement
+    components: [kbn]
+    text: "Don't logout users when they are not allowed to search a index-pattern"
+  - type: enhancement
+    components: [es]
+    text: "Headers obfuscation is now case insensitive ### What's new in 1.18.6"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.3.1, v7.3.2"
+  - type: new
+    components: [es]
+    text: "Configurable header names whose value should be obfuscated in logs"
+  - type: new
+    components: [kbn]
+    text: "Dynamic variables from user identity available in custom\\_logout\\_link"
+  - type: enhancement
+    components: [es]
+    text: "Richer logs for JWT errors"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🧐Enhancement** \\(ENT\\) nextUrl works also with SAML now"
+    type: enhancement
+    components_raw: "ENT"
+    text: "nextUrl works also with SAML now"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🧐Enhancement** \\(ENT\\) SAML assertion object available in ACL dynamic variables"
+    type: enhancement
+    components_raw: "ENT"
+    text: "SAML assertion object available in ACL dynamic variables"
+  - type: enhancement
+    components: [kbn]
+    text: "Validate LDAP server(s) before accepting new YAML settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Ensure a read-only UX for 'ro' users in older Kibana"
+  - type: fix
+    components: [es]
+    text: "Fix memory leak from dependency (snakeYAML) ### What's new in 1.18.5"
+  - type: fix
+    components: [es]
+    text: "indices rule can now properly handle also the templates API"
+  - type: enhancement
+    components: [es]
+    text: "Array dynamic variables are serialized as CSV wrapped in double quotes"
+  - type: enhancement
+    components: [es]
+    text: "Cleaner debug logs (no stacktraces on forbidden requests)"
+  - type: enhancement
+    components: [es]
+    text: "LDAP debug logs fire also when cache is hit"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES/KBN"
+    text: "Support v7.2.1, v7.3.0"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro
+    # original: "* **🐞Fix** \\(PRO\\) PRO plugin crashing for some Kibana versions"
+    type: fix
+    components_raw: "PRO"
+    text: "PRO plugin crashing for some Kibana versions"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) SAML library wrote a too large cookie sometimes"
+    type: fix
+    components_raw: "ENT"
+    text: "SAML library wrote a too large cookie sometimes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) SAML logout not working"
+    type: fix
+    components_raw: "ENT"
+    text: "SAML logout not working"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(ENT\\) JWT fix exception \"cannot set requestHeadersWhitelist\""
+    type: fix
+    components_raw: "ENT"
+    text: "JWT fix exception \"cannot set requestHeadersWhitelist\""
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Hide more UI elements for RO users"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Hide more UI elements for RO users"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Sometimes not all the available groups appear in tenancy selector"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Sometimes not all the available groups appear in tenancy selector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) Feature \"nextUrl\" broke"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "Feature \"nextUrl\" broke"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🐞Fix** \\(PRO/ENT\\) prevent user kick-out when APM is not configured and you are not an admin"
+    type: fix
+    components_raw: "PRO/ENT"
+    text: "prevent user kick-out when APM is not configured and you are not an admin"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,ent
+    # original: "* **🚀New** \\(PRO/ENT\\) Kibana request path/method now sent to ES \\(good for policing dev-tools\\) ### What's new in 1.18.4"
+    type: new
+    components_raw: "PRO/ENT"
+    text: "Kibana request path/method now sent to ES (good for policing dev-tools) ### What's new in 1.18.4"
+  - type: new
+    components: [es]
+    text: "User impersonation API"
+  - type: new
+    components: [es]
+    text: "Support latest 6.x and 5.x versions"
+  - type: fix
+    components: [es]
+    text: "filter/fields rules leak"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) allow more action for kibana\\_access, prevent sudden logout"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "allow more action for kibana\\_access, prevent sudden logout"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) temporarily roll back \"support for unlimited tenancies\" ### What's new in 1.18.3"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "temporarily roll back \"support for unlimited tenancies\" ### What's new in 1.18.3"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support added for ES/Kibana 6.8.1"
+    type: new
+    components_raw: "unspecified"
+    text: "Support added for ES/Kibana 6.8.1"
+  - type: enhancement
+    components: [es]
+    text: "Crash ES on invalid settings instead of stalling forever"
+  - type: enhancement
+    components: [es]
+    text: "Better logging on JWT, JSON-paths, LDAP, YAML errors"
+  - type: enhancement
+    components: [es]
+    text: "Block level settings validation to user with precious hints"
+  - type: enhancement
+    components: [es]
+    text: "If force\\_load\\_from\\_file: true, don't poll index settings"
+  - type: enhancement
+    components: [es]
+    text: "Order now counts declaring LDAP Failover HA servers"
+  - type: fix
+    components: [es]
+    text: "\"EsIndexJsonContentProvider\" had a null pointer exception"
+  - type: fix
+    components: [es]
+    text: "\"es.set.netty.runtime.available.processors\" exception"
+  - type: enhancement
+    components: [kbn]
+    text: "Collapsible logout button"
+  - type: enhancement
+    components: [kbn]
+    text: "ROR App now uses a HA http client"
+  - type: enhancement
+    components: [kbn]
+    text: "Automatic logout for inactivity"
+  - type: enhancement
+    components: [kbn]
+    text: "Support unlimited amount of tenancies"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:ent
+    # original: "* **🐞Fix** \\(KBN/ENT\\) concurrent multitenancy bug"
+    type: fix
+    components_raw: "KBN/ENT"
+    text: "concurrent multitenancy bug"
+  - type: fix
+    components: [kbn]
+    text: "Avoid sporadic errors on Save/Load buttons ### What's new in 1.18.2"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support for Elasticsearch & Kibana 7.2.0"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch & Kibana 7.2.0"
+  - type: fix
+    components: [es]
+    text: "restore indices (\"IDX\") in audit logging"
+  - type: enhancement
+    components: [es]
+    text: "New algorithm of setting evaluation order"
+  - type: new
+    components: [es]
+    text: "JWT claims as dynamic variables. I.e. \"@{jwt:claim.json.path}\""
+  - type: new
+    components: [es]
+    text: "\"explode\" dynamic variables. I.e. indices: \\[\"@explode{x-indices}\"\\]"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) preserve comments and formatting in YAML editor"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "preserve comments and formatting in YAML editor"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Print error message when session is expired"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Print error message when session is expired"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Regression** \\(PRO/Enterprise\\) Redirect to original link after login"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Redirect to original link after login"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Regression** \\(PRO/Enterprise\\) Broken CSV reporting"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Broken CSV reporting"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) Prevent navigating away from YAML editor w/ unsaved changes"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "Prevent navigating away from YAML editor w/ unsaved changes"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Exception when SAML connectors were all disabled"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Exception when SAML connectors were all disabled"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Concurrent tenants could mix up each other kibana index"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Concurrent tenants could mix up each other kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Cannot inject custom JS if no custom CSS was also declared"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Cannot inject custom JS if no custom CSS was also declared"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Injected JS had no effect on ROR logout button"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Injected JS had no effect on ROR logout button"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) On narrow screens, the YAML editor showed buttons twice ### What's new in 1.18.1"
+    type: fix
+    components_raw: "Enterprise"
+    text: "On narrow screens, the YAML editor showed buttons twice ### What's new in 1.18.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) Reindex requests failed for a regression in indices extraction"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "Reindex requests failed for a regression in indices extraction"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) Groups rule erratically failed"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "Groups rule erratically failed"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) JWT claims can now contain special characters"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "JWT claims can now contain special characters"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) Better ACL History logging"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "Better ACL History logging"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) QueryLogSerializer and old custom log serializers work again"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "QueryLogSerializer and old custom log serializers work again"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) ReadonlyREST icon in Kibana was white on white"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "ReadonlyREST icon in Kibana was white on white"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) SAML connectors could not be disabled"
+    type: fix
+    components_raw: "Enterprise"
+    text: "SAML connectors could not be disabled"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) SAML connector \"buttonName\" didn't work ### What's new in 1.18.0"
+    type: fix
+    components_raw: "Enterprise"
+    text: "SAML connector \"buttonName\" didn't work ### What's new in 1.18.0"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support for Elasticsearch & Kibana 7.0.1"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch & Kibana 7.0.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) empty array values in settings are invalid"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "empty array values in settings are invalid"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Security Fix** \\(Elasticsearch\\) arbitrary x-cluster search referencing local cluster"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "arbitrary x-cluster search referencing local cluster"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) ArrayOutOfBoundException on snapshot operations"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "ArrayOutOfBoundException on snapshot operations"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) History cleaning can now be disabled \\(\"clearSessionOnEvents\"\\) ### What's new in 1.17.7"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "History cleaning can now be disabled (\"clearSessionOnEvents\") ### What's new in 1.17.7"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support for Elasticsearch 7.0.0 \\(Kibana is coming soon\\)"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch 7.0.0 (Kibana is coming soon)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) rewritten LDAP connector"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "rewritten LDAP connector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancement** \\(Elasticsearch\\) new core written in Scala is now GA"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "new core written in Scala is now GA"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) devtools requests now honor the currently selected tenancy"
+    type: fix
+    components_raw: "Enterprise"
+    text: "devtools requests now honor the currently selected tenancy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Fix \"connectorsService\" error in installation ### What's new in 1.17.5"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Fix \"connectorsService\" error in installation ### What's new in 1.17.5"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.1"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.7.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,gt;= kibana 6.6.0
+    # original: "* **🧐Enhancement** \\(Enterprise &gt;= Kibana 6.6.0\\) Multiple SAML identity provider"
+    type: enhancement
+    components_raw: "Enterprise &gt;= Kibana 6.6.0"
+    text: "Multiple SAML identity provider"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Don't pass auth headers back to the browser"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Don't pass auth headers back to the browser"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Fix** \\(Enterprise/PRO\\) Missing null check caused error in reporting \\(CSV\\)"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Missing null check caused error in reporting (CSV)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Don't reject requests if SAML groups are not configured"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Don't reject requests if SAML groups are not configured"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** filter/fields rules not working in msearch \\(in 6.7.x\\)"
+    type: fix
+    components_raw: "unspecified"
+    text: "filter/fields rules not working in msearch (in 6.7.x)"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Print whole LDAP search query in debug log ### What's new in 1.17.4"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Print whole LDAP search query in debug log ### What's new in 1.17.4"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New** Support for Kibana/Elasticsearch 6.7.0"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.7.0"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) JWT query param is the preferred credentials provider"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "JWT query param is the preferred credentials provider"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) admin users can use indices management"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "admin users can use indices management"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement** \\(PRO/Enterprise\\) ro users can dismiss telemetry form"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "ro users can dismiss telemetry form"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
+    type: fix
+    components_raw: "unspecified"
+    text: "Audit logging in 5.1.x now works again"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** unpredictable behaviour of \"filter\" and \"fields\" when using external auth"
+    type: fix
+    components_raw: "unspecified"
+    text: "unpredictable behaviour of \"filter\" and \"fields\" when using external auth"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** LDAP ConcurrentModificationException"
+    type: fix
+    components_raw: "unspecified"
+    text: "LDAP ConcurrentModificationException"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Audit logging in 5.1.x now works again"
+    type: fix
+    components_raw: "unspecified"
+    text: "Audit logging in 5.1.x now works again"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "JWT deep-link works again ### What's new in 1.17.3 1.17.2 went unreleased, all changes have been merged in 1.17.3 directly"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Tenancy selector showing if user belonged to one group"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Tenancy selector showing if user belonged to one group"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) RW buttons not hiding for RO users in React Kibana apps"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "RW buttons not hiding for RO users in React Kibana apps"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Tenancy templating now works much more reliably"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Tenancy templating now works much more reliably"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Missing tenancy selector icon after switching tenancy"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Missing tenancy selector icon after switching tenancy"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) barring static files requests caused sudden logout"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "barring static files requests caused sudden logout"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Numerous fixes to better support Kibana 6.6.x"
+    type: fix
+    components_raw: "unspecified"
+    text: "Numerous fixes to better support Kibana 6.6.x"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Critical fixes in new Scala core"
+    type: fix
+    components_raw: "unspecified"
+    text: "Critical fixes in new Scala core"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Exception in reindex requests caused tenancy templating to fail"
+    type: fix
+    components_raw: "unspecified"
+    text: "Exception in reindex requests caused tenancy templating to fail"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Bypass cross-cluster search logic if single cluster ### What's new in 1.17.1"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) SAML now works well in 6.6.x"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "SAML now works well in 6.6.x"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) \"undefined\" authentication error before login"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "\"undefined\" authentication error before login"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Default space creation failures for new tenants"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Default space creation failures for new tenants"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Icons/titles CSS misalignment in sidebar \\(Firefox\\)"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Icons/titles CSS misalignment in sidebar (Firefox)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🧐Enhancement**\\(Enterprise\\) UX: Larger tenancy selector"
+    type: enhancement
+    components_raw: "Enterprise"
+    text: "UX: Larger tenancy selector"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Security Fix** \\(Enterprise\\) Privilege escalation when changing tenancies under monitoring"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Privilege escalation when changing tenancies under monitoring"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞Fix** \\(Elasticsearch\\) compatibility fixes to support new Kibana features"
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "compatibility fixes to support new Kibana features"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🧐Enhancements** \\(Elasticsearch\\) New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0"
+    type: enhancement
+    components_raw: "Elasticsearch"
+    text: "New core and LDAP connector written in Scala is finished, now under QA. ### What's new in 1.17.0"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** Support for Kibana/Elasticsearch 6.6.0, 6.6.1"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Kibana/Elasticsearch 6.6.0, 6.6.1"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** Internode SSL \\(ES 6.3.x onwards\\)"
+    type: new
+    components_raw: "unspecified"
+    text: "Internode SSL (ES 6.3.x onwards)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🧐Enhancement**\\(PRO/Enterprise\\) UI appearence"
+    type: enhancement
+    components_raw: "PRO/Enterprise"
+    text: "UI appearence"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Made HTTP Connection configurable \\(PR \\#410\\)"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Made HTTP Connection configurable (PR \\#410)"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** slow boot due to SecureRandom waiting for sufficient entropy"
+    type: fix
+    components_raw: "unspecified"
+    text: "slow boot due to SecureRandom waiting for sufficient entropy"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix** Enable kibana\\_access:ro to create short urls in es6.3+ \\(PR \\#408\\) ### What's new in 1.16.34"
+    type: fix
+    components_raw: "unspecified"
+    text: "Enable kibana\\_access:ro to create short urls in es6.3+ (PR \\#408) ### What's new in 1.16.34"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** X-Forwarded-For header in printed es logs \\(\"XFF\"\\)"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "X-Forwarded-For header in printed es logs (\"XFF\")"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** kibana_index: \".kibana_@{user}\" when user is \"John Doe\" becomes .kibana\\_john\\_doe"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "kibana_index: \".kibana_@{user}\" when user is \"John Doe\" becomes .kibana\\_john\\_doe"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🐞Fix** \\(Enteprise\\) parse SAML groups from assertion as array of strings"
+    type: fix
+    components_raw: "Enteprise"
+    text: "parse SAML groups from assertion as array of strings"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🐞Fix** \\(Enteprise\\) SAMLRequest in location header was URLEncoded twice, broke on some IdP"
+    type: fix
+    components_raw: "Enteprise"
+    text: "SAMLRequest in location header was URLEncoded twice, broke on some IdP"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix** \\(PRO/Enteprise\\) \"cookiePass\" works again, no more need for sticky cookies in load balancers!"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "\"cookiePass\" works again, no more need for sticky cookies in load balancers!"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix** \\(PRO/Enteprise\\) fix redirect loop with JWT deep linking when JWT token expires"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "fix redirect loop with JWT deep linking when JWT token expires"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🧐Enhancement** \\(PRO/Enteprise\\) fix audit demo page CSS"
+    type: enhancement
+    components_raw: "PRO/Enteprise"
+    text: "fix audit demo page CSS"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enteprise
+    # original: "* **🧐Enhancement** \\(Enteprise\\) SAML more configuration parameters available"
+    type: enhancement
+    components_raw: "Enteprise"
+    text: "SAML more configuration parameters available"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🚀New Feature** \\(PRO/Enteprise\\) set ROR to debug mode \\(readonlyrest\\_kbn.logLevel: \"debug\"\\) ### What's new in 1.16.33"
+    type: new
+    components_raw: "PRO/Enteprise"
+    text: "set ROR to debug mode (readonlyrest\\_kbn.logLevel: \"debug\") ### What's new in 1.16.33"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) compatibility problems with older Kibana versions"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "compatibility problems with older Kibana versions"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) compatibility problems with OSS Kibana version ### What's new in 1.16.32"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "compatibility problems with OSS Kibana version ### What's new in 1.16.32"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** \"kibanaIndexTemplate\": default dashboards and spaces for new tenants"
+    type: new
+    components_raw: "unspecified"
+    text: "\"kibanaIndexTemplate\": default dashboards and spaces for new tenants"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.4"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.5.4"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Upgraded LDAP library"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Upgraded LDAP library"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🧐Enhancement** \\(Enterprise\\) Now tenants save their CSV exports in their own reporting index"
+    type: enhancement
+    components_raw: "Enterprise"
+    text: "Now tenants save their CSV exports in their own reporting index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enteprise
+    # original: "* **🐞Fix**\\(PRO/Enteprise\\) Support passwords that start and/or end with spaces"
+    type: fix
+    components_raw: "PRO/Enteprise"
+    text: "Support passwords that start and/or end with spaces"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Now reporting works again ### What's new in 1.16.31"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Now reporting works again ### What's new in 1.16.31"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.5.2, 6.5.3"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.5.2, 6.5.3"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* **🚧WIP**: Laid out the foundation for LDAP HA support ### What's new in 1.16.29"
+    type: <unknown>
+    components_raw: "unspecified"
+    text: ": Laid out the foundation for LDAP HA support ### What's new in 1.16.29"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.3"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.3"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🚀New Feature** \\(PRO/Enterprise\\) configurable server side session duration"
+    type: new
+    components_raw: "PRO/Enterprise"
+    text: "configurable server side session duration"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** \\[LDAP\\] High Availability: Round Robin or Failover ### What's new in 1.16.28"
+    type: new
+    components_raw: "unspecified"
+    text: "\\[LDAP\\] High Availability: Round Robin or Failover ### What's new in 1.16.28"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.2"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.2"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞Fix** \\(Enterprise\\) Multi tenancy: sometimes changing tenancy would not change kibana index"
+    type: fix
+    components_raw: "Enterprise"
+    text: "Multi tenancy: sometimes changing tenancy would not change kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Security Fix** \\(Enterprise/PRO\\) Avoid echoing Base64 encoded credentials in login form error message"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Avoid echoing Base64 encoded credentials in login form error message"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) Remove latest search/visualization/dashboard history on logout"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "Remove latest search/visualization/dashboard history on logout"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) Clear transient authentication cookies on login error to avoid authentication deadlocks"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "Clear transient authentication cookies on login error to avoid authentication deadlocks"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞Fix**: External JWT verification may throw ArrayOutOfBoundException"
+    type: fix
+    components_raw: "unspecified"
+    text: ": External JWT verification may throw ArrayOutOfBoundException"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_type
+    # original: "* **🚧WIP**: Laid out the foundation for internode SSL transport \\(port 9300\\) ### What's new in 1.16.27"
+    type: <unknown>
+    components_raw: "unspecified"
+    text: ": Laid out the foundation for internode SSL transport (port 9300) ### What's new in 1.16.27"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** \\[JWT\\] external validator: it's now possible to avoid storing the private key in settings"
+    type: new
+    components_raw: "unspecified"
+    text: "\\[JWT\\] external validator: it's now possible to avoid storing the private key in settings"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES/Kibana 6.4.1"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES/Kibana 6.4.1"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Rewritten big part of ES plugin [documentation](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md)"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** SAML Single log out flow"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "SAML Single log out flow"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Fix** \\(Enterprise/PRO\\) [cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB."
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "[cookiePass](https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#common-cookie-encryption-secret) works again, but only for Kibana 5.x. Newer Kibana needs sticky sessions in LB."
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🧐Enhancement** \\(Enterprise/PRO\\) much faster logout ### What's new in 1.16.26"
+    type: enhancement
+    components_raw: "Enterprise/PRO"
+    text: "much faster logout ### What's new in 1.16.26"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) bugs during plugin packaging and installation process ### What's new in 1.16.25"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "bugs during plugin packaging and installation process ### What's new in 1.16.25"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** Users rule: easily restrict external authentication to a list of users"
+    type: new
+    components_raw: "unspecified"
+    text: "Users rule: easily restrict external authentication to a list of users"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for ES 5.6.11"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for ES 5.6.11"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise,pro
+    # original: "* **🐞Hot Fix** \\(Enterprise/PRO\\) Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24"
+    type: fix
+    components_raw: "Enterprise/PRO"
+    text: "Error 404 when logging in with older versions of Kibana ### What's new in 1.16.24"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) SAML Authentication"
+    type: new
+    components_raw: "Enterprise"
+    text: "SAML Authentication"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** Support for Elasticsearch and Kibana 6.4.0"
+    type: new
+    components_raw: "unspecified"
+    text: "Support for Elasticsearch and Kibana 6.4.0"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature** Headers rule now split in headers\\_or and headers\\_and"
+    type: new
+    components_raw: "unspecified"
+    text: "Headers rule now split in headers\\_or and headers\\_and"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Headers rule now allows wildcards"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Headers rule now allows wildcards"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Multi-tenancy now works also with JSON groups provider"
+    type: new
+    components_raw: "Enterprise"
+    text: "Multi-tenancy now works also with JSON groups provider"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞 Fix** Multi-tenancy \\(Enterprise\\) incoherent initial kibana\\_index and current group ### What's new in 1.16.23"
+    type: fix
+    components_raw: "unspecified"
+    text: "Multi-tenancy (Enterprise) incoherent initial kibana\\_index and current group ### What's new in 1.16.23"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Support for Elastic Stack 6.3.1 and 5.6.10"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Support for Elastic Stack 6.3.1 and 5.6.10"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Custom CSS injection for Kibana"
+    type: new
+    components_raw: "Enterprise"
+    text: "Custom CSS injection for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🚀New Feature** \\(Enterprise\\) Custom Javascript injection for Kibana"
+    type: new
+    components_raw: "Enterprise"
+    text: "Custom Javascript injection for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🚀New Feature** \\(PRO/Enterprise\\) access paths without need to login \\(i.e. /api/status\\)"
+    type: new
+    components_raw: "PRO/Enterprise"
+    text: "access paths without need to login (i.e. /api/status)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞Fix** \\(PRO/Enterprise\\) Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "Navigating to X-Pack APM caused hidden Kibana apps to reappear ### What's new in 1.16.22"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature:**  map LDAP groups to local groups \\(a.k.a. role mapping\\)"
+    type: new
+    components_raw: "unspecified"
+    text: "map LDAP groups to local groups (a.k.a. role mapping)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:elasticsearch
+    # original: "* **🐞 Fix** \\(Elasticsearch\\) wildcard aliases resolution not working in \"indices\" rule."
+    type: fix
+    components_raw: "Elasticsearch"
+    text: "wildcard aliases resolution not working in \"indices\" rule."
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement:** it is now possible now to use JDK 9 and 10"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "it is now possible now to use JDK 9 and 10"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) wait forever for login request \\(i.e.  slow LDAP servers\\)"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "wait forever for login request (i.e.  slow LDAP servers)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) add spinner and block UI if login request is being sent"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "add spinner and block UI if login request is being sent"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) if user is logged out because of LDAP cache expiring + slow authentication, redirect to login."
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "if user is logged out because of LDAP cache expiring + slow authentication, redirect to login."
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro,enterprise
+    # original: "* **🐞 Fix** \\(PRO/Enterprise\\) let RO users delete/edit search filters ### What's new in 1.16.21"
+    type: fix
+    components_raw: "PRO/Enterprise"
+    text: "let RO users delete/edit search filters ### What's new in 1.16.21"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature:** Introducing support for Elasticsearch and Kibana v6.3.0"
+    type: new
+    components_raw: "unspecified"
+    text: "Introducing support for Elasticsearch and Kibana v6.3.0"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:enterprise
+    # original: "* **🐞 Fix** \\(Enterprise\\) multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
+    type: fix
+    components_raw: "Enterprise"
+    text: "multi tenancy - switching tenancy does not always switch kibana index ### What's new in 1.16.20 ## ReadonlyREST PRO/Enterprise for Kibana"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐 Enhancement**: when login, forward \"elasticsearch.requestHeadersWhitelist\" headers. \\(useful for \"headers\" rule  and \"proxy\\_auth\" to work well.\\) ## ReadonlyREST for Elasticsearch"
+    type: enhancement
+    components_raw: "unspecified"
+    text: ": when login, forward \"elasticsearch.requestHeadersWhitelist\" headers. (useful for \"headers\" rule  and \"proxy\\_auth\" to work well.) ## ReadonlyREST for Elasticsearch"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀New Feature**: DLS \\(with dynamic variables suppoort\\) Thanks [DataSweet](http://www.datasweet.fr/)!"
+    type: new
+    components_raw: "unspecified"
+    text: ": DLS (with dynamic variables suppoort) Thanks [DataSweet](http://www.datasweet.fr/)!"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀 New feature**: Field level security"
+    type: new
+    components_raw: "unspecified"
+    text: ": Field level security"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🚀 New rules**: Snapshot, Repositories, Headers"
+    type: new
+    components_raw: "unspecified"
+    text: ": Snapshot, Repositories, Headers"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐 Enhancement**: custom audit serializers: the request content is available"
+    type: enhancement
+    components_raw: "unspecified"
+    text: ": custom audit serializers: the request content is available"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞 Fix** readonlyrest.yml path discovery"
+    type: fix
+    components_raw: "unspecified"
+    text: "readonlyrest.yml path discovery"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞 Fix:** LDAP available groups discovery \\(tenancy switcher\\) corner cases"
+    type: fix
+    components_raw: "unspecified"
+    text: "LDAP available groups discovery (tenancy switcher) corner cases"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞 Fix**: auth\\_key\\_sha1, auth\\_key\\_sha256 hashes in settings should be case insensitive"
+    type: fix
+    components_raw: "unspecified"
+    text: ": auth\\_key\\_sha1, auth\\_key\\_sha256 hashes in settings should be case insensitive"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🐞 Fix**: LDAP authentication didn't work with local group"
+    type: fix
+    components_raw: "unspecified"
+    text: ": LDAP authentication didn't work with local group"

--- a/changelog/1.26.0.yaml
+++ b/changelog/1.26.0.yaml
@@ -1,0 +1,3 @@
+version: "1.26.0"
+release_date: "2021-01-02"
+entries:

--- a/changelog/1.26.1.yaml
+++ b/changelog/1.26.1.yaml
@@ -1,3 +1,6 @@
 version: "1.26.1"
 release_date: "2021-01-11"
 entries:
+  - type: fix
+    components: [es]
+    text: "wrong behaviour of `kibana_access` rule for ROR actions when ADMIN value is set"

--- a/changelog/1.26.1.yaml
+++ b/changelog/1.26.1.yaml
@@ -1,0 +1,3 @@
+version: "1.26.1"
+release_date: "2021-01-11"
+entries:

--- a/changelog/1.27.0.yaml
+++ b/changelog/1.27.0.yaml
@@ -1,0 +1,3 @@
+version: "1.27.0"
+release_date: "2021-02-16"
+entries:

--- a/changelog/1.27.0.yaml
+++ b/changelog/1.27.0.yaml
@@ -1,3 +1,21 @@
 version: "1.27.0"
 release_date: "2021-02-16"
 entries:
+  - type: new
+    components: [es]
+    text: "7.11.0, 7.10.2, 6.8.14 support"
+  - type: enhancement
+    components: [kbn]
+    text: "X-Forwarded-For copied from incoming request (or filled with source IP) before forwarding to ES"
+  - type: enhancement
+    components: [kbn]
+    text: "Kibana logout event generates a special audit log entry in ROR audit logs index"
+  - type: enhancement
+    components: [kbn]
+    text: "ROR panel shows \"reports\" button if kibana:management app is hidden"
+  - type: fix
+    components: [es]
+    text: "[blocks containing filter and/or fields won't match internal kibana requests, so kibana\\_\\* rules won't have to be placed in such blocks](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#fields)"
+  - type: fix
+    components: [es]
+    text: "SQL API - better handling of invalid query"

--- a/changelog/1.27.1.yaml
+++ b/changelog/1.27.1.yaml
@@ -1,0 +1,3 @@
+version: "1.27.1"
+release_date: "2021-02-27"
+entries:

--- a/changelog/1.27.1.yaml
+++ b/changelog/1.27.1.yaml
@@ -1,3 +1,9 @@
 version: "1.27.1"
 release_date: "2021-02-27"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290)"
+  - type: new
+    components: [es]
+    text: "7.11.1 support"

--- a/changelog/1.28.0.yaml
+++ b/changelog/1.28.0.yaml
@@ -1,0 +1,3 @@
+version: "1.28.0"
+release_date: "2021-03-14"
+entries:

--- a/changelog/1.28.0.yaml
+++ b/changelog/1.28.0.yaml
@@ -1,3 +1,27 @@
 version: "1.28.0"
 release_date: "2021-03-14"
 entries:
+  - type: new
+    components: [es]
+    text: "7.12.0, 7.11.2 support"
+  - type: new
+    components: [es]
+    text: "full [Index and Component Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/index-templates.html) support"
+  - type: enhancement
+    components: [es]
+    text: "[Username case sensitivity settings](https://forum.readonlyrest.com/t/ldap-based-user-authentication/1667)"
+  - type: fix
+    components: [es]
+    text: "[Kibana logout event storing fix](https://forum.readonlyrest.com/t/kibana-plugin-software-licensing-and-expiration/1808/5)"
+  - type: fix
+    components: [es]
+    text: "[Fixed remote reindex operation with \"type\" parameter](https://forum.readonlyrest.com/t/reindex-index-not-found-exception/1708/20)"
+  - type: fix
+    components: [kbn]
+    text: "Prevent cookie expiration deadlock in browsers when using SAML/OIDC"
+  - type: fix
+    components: [kbn]
+    text: "When credentials change in the ACL, make it possible to login again"
+  - type: fix
+    components: [kbn]
+    text: "Kibana management app ID changed from \"kibana:management\" to \"kibana:stack\\_management\""

--- a/changelog/1.28.1.yaml
+++ b/changelog/1.28.1.yaml
@@ -1,3 +1,9 @@
 version: "1.28.1"
 release_date: "2021-03-24"
 entries:
+  - type: fix
+    components: [es]
+    text: "Getting index templates issue when no `indices` rule was used in matched block"
+  - type: fix
+    components: [es]
+    text: "[NPE on getting template aliases](https://forum.readonlyrest.com/t/cannot-put-index-template-template-1/1681/25)"

--- a/changelog/1.28.1.yaml
+++ b/changelog/1.28.1.yaml
@@ -1,0 +1,3 @@
+version: "1.28.1"
+release_date: "2021-03-24"
+entries:

--- a/changelog/1.28.2.yaml
+++ b/changelog/1.28.2.yaml
@@ -1,3 +1,9 @@
 version: "1.28.2"
 release_date: "2021-04-01"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295)"
+  - type: fix
+    components: [kbn]
+    text: "prevent SAML/OIDC initiated Kibana sessions from expiring after `session_timeout_minutes` despite continued interaction"

--- a/changelog/1.28.2.yaml
+++ b/changelog/1.28.2.yaml
@@ -1,0 +1,3 @@
+version: "1.28.2"
+release_date: "2021-04-01"
+entries:

--- a/changelog/1.29.0.yaml
+++ b/changelog/1.29.0.yaml
@@ -1,3 +1,15 @@
 version: "1.29.0"
 release_date: "2021-04-09"
 entries:
+  - type: security
+    components: [es]
+    text: "Security Fix (ES) [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409)"
+  - type: new
+    components: [kbn]
+    text: "support 7.9.0, 7.9.1, 7.10.0, 7.10.1, 7.10.2, 7.11.0, 7.11.1, 7.11.2 ([with ROR new platform](https://beta.readonlyrest.com/))"
+  - type: new
+    components: [es]
+    text: "7.12.1 support"
+  - type: enhancement
+    components: [kbn]
+    text: "logout if the credentials/metadata of the current user change in the ACL"

--- a/changelog/1.29.0.yaml
+++ b/changelog/1.29.0.yaml
@@ -1,0 +1,3 @@
+version: "1.29.0"
+release_date: "2021-04-09"
+entries:

--- a/changelog/1.30.0.yaml
+++ b/changelog/1.30.0.yaml
@@ -1,0 +1,3 @@
+version: "1.30.0"
+release_date: "2021-05-16"
+entries:

--- a/changelog/1.30.0.yaml
+++ b/changelog/1.30.0.yaml
@@ -1,3 +1,36 @@
 version: "1.30.0"
 release_date: "2021-05-16"
 entries:
+  - type: new
+    components: [kbn]
+    text: "7.12.x compatibility"
+  - type: new
+    components: [es]
+    text: "[LDAP connector circuit breaker](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#circuit-breaker)"
+  - type: enhancement
+    components: [es]
+    text: "[Username with wildcard support in users section](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#groups) and [groups mapping](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.30.x/elasticsearch.md#group-mapping)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) OIDC errors visibility"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "OIDC errors visibility"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) Smarter session probe algorithm"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "Smarter session probe algorithm"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:gt;= 7.9.x
+    # original: "* **🐞Fix** \\(KBN &gt;= 7.9.x\\) [Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)"
+    type: fix
+    components_raw: "KBN &gt;= 7.9.x"
+    text: "[Load CertificateAuthorities as an array if not specified as an array](https://forum.readonlyrest.com/t/kibana-crash-at-startup-with-the-new-7-10-2-version/1840)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) Don't hide visualizations list search box in RO mode"
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "Don't hide visualizations list search box in RO mode"

--- a/changelog/1.30.1.yaml
+++ b/changelog/1.30.1.yaml
@@ -1,0 +1,3 @@
+version: "1.30.1"
+release_date: "2021-05-26"
+entries:

--- a/changelog/1.30.1.yaml
+++ b/changelog/1.30.1.yaml
@@ -1,3 +1,15 @@
 version: "1.30.1"
 release_date: "2021-05-26"
 entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)"
+  - type: new
+    components: [es]
+    text: "7.13.0, 7.13.1 support"
+  - type: fix
+    components: [es]
+    text: "Regression in multi-tenancy handling"
+  - type: fix
+    components: [es]
+    text: "Proper handling of \\_snapshot/\\_status endpoint"

--- a/changelog/1.31.0.yaml
+++ b/changelog/1.31.0.yaml
@@ -1,3 +1,45 @@
 version: "1.31.0"
 release_date: "2021-06-29"
 entries:
+  - type: security
+    components: [kbn]
+    text: "prevent direct navigation to hidden apps"
+  - type: new
+    components: [es]
+    text: "7.13.4, 7.13.3, 7.13.2, 6.8.17 support"
+  - type: new
+    components: [kbn]
+    text: "new minimal Kibana Management menu when \"Management\" app is hidden"
+  - type: enhancement
+    components: [kbn]
+    text: "logout active Kibana session if key metadata/permissions change in ACL"
+  - type: enhancement
+    components: [kbn]
+    text: "better port number validation"
+  - type: enhancement
+    components: [es]
+    text: "improved cluster indices handling"
+  - type: fix
+    components: [es]
+    text: "[Kibana access rule regression fix](https://forum.readonlyrest.com/t/es7-11-2-1-30-0-enterprise-two-contexts-rw-ro-issue/1855)"
+  - type: fix
+    components: [es]
+    text: "search template API handling with `filter` and `fields` rule"
+  - type: fix
+    components: [es]
+    text: "multi-tenancy issue when groups_provider_authorization is used"
+  - type: fix
+    components: [es]
+    text: "`x_forwarded_for` rule: wrong handling of / request"
+  - type: fix
+    components: [es]
+    text: "Issue with handling ResizeRequest which made it unable to upgrade Kibana to version 7.12.0+"
+  - type: fix
+    components: [kbn]
+    text: "some Kibana requests arrive to ES without credentials"
+  - type: fix
+    components: [kbn]
+    text: "inconsistent read after write in session storage lead to issues with round robin load balancing"
+  - type: fix
+    components: [kbn]
+    text: "bad multipart POST handling leads to saved object import errors"

--- a/changelog/1.31.0.yaml
+++ b/changelog/1.31.0.yaml
@@ -1,0 +1,3 @@
+version: "1.31.0"
+release_date: "2021-06-29"
+entries:

--- a/changelog/1.32.0.yaml
+++ b/changelog/1.32.0.yaml
@@ -1,0 +1,3 @@
+version: "1.32.0"
+release_date: "2021-07-25"
+entries:

--- a/changelog/1.32.0.yaml
+++ b/changelog/1.32.0.yaml
@@ -1,3 +1,54 @@
 version: "1.32.0"
 release_date: "2021-07-25"
 entries:
+  - type: security
+    components: [es]
+    text: "[Apache Commons Codec vulnerability](https://forum.readonlyrest.com/t/security-vulnerability-for-common-codec-1-10/1906)"
+  - type: security
+    components: [kbn]
+    text: "upgraded dependencies due to security fixes"
+  - type: security
+    components: [kbn]
+    text: "disable x-powered-by to avoid fingerprinting"
+  - type: new
+    components: [es]
+    text: "Support for ES 7.14.0 & 6.8.18"
+  - type: new
+    components: [kbn]
+    text: "Support for Kibana 7.13.x series"
+  - type: enhancement
+    components: [kbn]
+    text: "honor configurations coming from ENV and CLI options"
+  - type: enhancement
+    components: [kbn]
+    text: "when metadata has no username, login must be denied"
+  - type: enhancement
+    components: [kbn]
+    text: "audit tab ported to new platform"
+  - type: enhancement
+    components: [es]
+    text: "improved ES resources cleaning when ROR returns FORBIDDEN response"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🧐Enhancement** \\(KBN &lt; 7.9.x\\) auto clean-up dangling SAML/OIDC cookies"
+    type: enhancement
+    components_raw: "KBN &lt; 7.9.x"
+    text: "auto clean-up dangling SAML/OIDC cookies"
+  - type: fix
+    components: [es]
+    text: "[incomplete response for request GET */_alias](https://forum.readonlyrest.com/t/ror-return-incomplete-response-for-request-get-alias/1872)"
+  - type: fix
+    components: [es]
+    text: "not allowed aliases should not present in a response for a Get Index API request"
+  - type: fix
+    components: [kbn]
+    text: "fix dev-tools and import saved object not working"
+  - type: fix
+    components: [kbn]
+    text: "honor `requestHeadersWhitelist` in user metadata request (login)"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) do not crash on invalid metadata  "
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "do not crash on invalid metadata"

--- a/changelog/1.33.0.yaml
+++ b/changelog/1.33.0.yaml
@@ -1,3 +1,24 @@
 version: "1.33.0"
 release_date: "2021-08-09"
 entries:
+  - type: security
+    components: [kbn]
+    text: "xml-crypto dependency update"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.14.0, 6.8.18"
+  - type: enhancement
+    components: [kbn]
+    text: "Parse credentials in /api/* requests, no need for valid cookie. Supersedes whitelistedPaths"
+  - type: fix
+    components: [kbn]
+    text: "Caching issues switching tenancies with dark/light theme"
+  - type: fix
+    components: [kbn]
+    text: "Newly created Space shows in all tenancies when using default kibana index"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:lt; 7.9.x
+    # original: "* **🐞Fix** \\(KBN &lt; 7.9.x\\) nextUrl works again with SAML and OIDC"
+    type: fix
+    components_raw: "KBN &lt; 7.9.x"
+    text: "nextUrl works again with SAML and OIDC"

--- a/changelog/1.33.0.yaml
+++ b/changelog/1.33.0.yaml
@@ -1,0 +1,3 @@
+version: "1.33.0"
+release_date: "2021-08-09"
+entries:

--- a/changelog/1.33.1.yaml
+++ b/changelog/1.33.1.yaml
@@ -1,3 +1,15 @@
 version: "1.33.1"
 release_date: "2021-08-14"
 entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.14.1"
+  - type: fix
+    components: [kbn]
+    text: "Error in patching for 7.14.0"
+  - type: fix
+    components: [kbn]
+    text: "clearSessionOnEvents now works as expected"
+  - type: fix
+    components: [kbn]
+    text: "login form font loads correctly"

--- a/changelog/1.33.1.yaml
+++ b/changelog/1.33.1.yaml
@@ -1,0 +1,3 @@
+version: "1.33.1"
+release_date: "2021-08-14"
+entries:

--- a/changelog/1.34.0.yaml
+++ b/changelog/1.34.0.yaml
@@ -1,3 +1,27 @@
 version: "1.34.0"
 release_date: "2021-09-24"
 entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.0, 7.14.2"
+  - type: new
+    components: [kbn]
+    text: "VS Code style YAML editor"
+  - type: new
+    components: [kbn]
+    text: "Skip rendering hidden app groups entirely"
+  - type: new
+    components: [kbn]
+    text: "Redesigned ROR Menu"
+  - type: new
+    components: [kbn]
+    text: "Dark theme awareness"
+  - type: fix
+    components: [kbn]
+    text: "Broken Kibana Spaces"
+  - type: fix
+    components: [kbn]
+    text: "Support Kibana's undocumented \"server.ssl.*\" settings"
+  - type: fix
+    components: [kbn]
+    text: "cookiePass config parsing broke load balancing"

--- a/changelog/1.34.0.yaml
+++ b/changelog/1.34.0.yaml
@@ -1,0 +1,3 @@
+version: "1.34.0"
+release_date: "2021-09-24"
+entries:

--- a/changelog/1.35.0.yaml
+++ b/changelog/1.35.0.yaml
@@ -1,3 +1,57 @@
 version: "1.35.0"
 release_date: "2021-10-12"
 entries:
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.0, 7.14.2"
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.1, 6.8.19, 6.8.20"
+  - type: enhancement
+    components: [es]
+    text: "[local->external groups detailed mapping for groups rule](https://github.com/beshu-tech/readonlyrest-docs/blob/master/details/groups-rule-mapping.md)"
+  - type: enhancement
+    components: [es]
+    text: "when ROR is starting any request is going to end up with HTTP 403 response, instead of HTTP 503"
+  - type: enhancement
+    components: [kbn]
+    text: "\"server.basePath\" kibana option implementation"
+  - type: enhancement
+    components: [kbn]
+    text: "Support full regex in kibana_hidden_apps rule"
+  - # EDGE CASE — manual review needed
+    # reason: no_component_specified
+    # original: "* **🧐Enhancement** Crash if Kibana is not patched"
+    type: enhancement
+    components_raw: "unspecified"
+    text: "Crash if Kibana is not patched"
+  - type: enhancement
+    components: [kbn]
+    text: "Honour kibana setting \"logging.dest\""
+  - type: enhancement
+    components: [kbn]
+    text: "Confirm before overwriting audit log dashboard"
+  - type: fix
+    components: [es]
+    text: "verbosity: error fix in case of ROR KBN login request"
+  - type: fix
+    components: [kbn]
+    text: "Make alerting work on primary tenancy"
+  - type: fix
+    components: [kbn]
+    text: "OIDC fix sameSite / secure cookie options"
+  - type: fix
+    components: [kbn]
+    text: "Login form is stretched when long error"
+  - type: fix
+    components: [kbn]
+    text: "Login form is stretched when long error"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn-pro
+    # original: "* **🐞Fix** (KBN-PRO) [Don't send x-ror-currentgroup in PRO](https://forum.readonlyrest.com/t/upgrading-6-7-w-1-18-to-7-14-w-1-33-ldap-from-ms-active-directory-no-longer-understands-multiple-ad-group-memberships/1973/6)"
+    type: fix
+    components_raw: "KBN-PRO"
+    text: "[Don't send x-ror-currentgroup in PRO](https://forum.readonlyrest.com/t/upgrading-6-7-w-1-18-to-7-14-w-1-33-ldap-from-ms-active-directory-no-longer-understands-multiple-ad-group-memberships/1973/6)"
+  - type: fix
+    components: [kbn]
+    text: "Resolve browser console errors on a popover close"

--- a/changelog/1.35.0.yaml
+++ b/changelog/1.35.0.yaml
@@ -1,0 +1,3 @@
+version: "1.35.0"
+release_date: "2021-10-12"
+entries:

--- a/changelog/1.35.1.yaml
+++ b/changelog/1.35.1.yaml
@@ -1,0 +1,27 @@
+version: "1.35.1"
+release_date: "2021-10-17"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) & [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)"
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.1"
+  - type: new
+    components: [es]
+    text: "New Support for 7.15.2"
+  - type: enhancement
+    components: [kbn]
+    text: "Support \"server.ssl.supportedProtocols\" settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Support \"server.ssl.cipherSuites\""
+  - type: enhancement
+    components: [kbn]
+    text: "Always honor SSL cipher order"
+  - type: fix
+    components: [kbn]
+    text: "Don'thide \"Add/Remove field as column\" in Discover app for RO users"
+  - type: fix
+    components: [kbn]
+    text: "More alerting fixes (only for main tenancy)"

--- a/changelog/1.36.0.yaml
+++ b/changelog/1.36.0.yaml
@@ -1,0 +1,48 @@
+version: "1.36.0"
+release_date: "2021-11-21"
+entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.16.1, 7.16.0, 6.8.21"
+  - type: new
+    components: [kbn]
+    text: "Support Kibana 7.15.2"
+  - type: new
+    components: [es]
+    text: "[Added support for setting up cluster containing ES with ROR (with disabled XPack security) and ES with XPack security enabled](https://forum.readonlyrest.com/t/ssl-internode-with-elk-cluster/1916)"
+  - type: enhancement
+    components: [kbn]
+    text: "kibana_hide_apps: [ror|kibana] to remove kibana mgmt button"
+  - type: fix
+    components: [es]
+    text: "[/_snapshot/_status should return only running snapshots](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/756)"
+  - type: fix
+    components: [es]
+    text: "[Adding policy to index template bug](https://forum.readonlyrest.com/t/forbidden-by-readonlyrest-es-plugin-with-add-policy-to-index-template-action-in-kibana/1969)"
+  - type: fix
+    components: [kbn]
+    text: "Index management tabs result in \"forbidden\" error"
+  - type: fix
+    components: [kbn]
+    text: "[corrupted patch file for Kibana 7.9.x](https://forum.readonlyrest.com/t/ror-1-35-1-kibana-7-9-3-unable-to-patch/2018)"
+  - type: fix
+    components: [kbn]
+    text: "[YAML editor not working in air-gapped environments](https://forum.readonlyrest.com/t/readonlyrest-security-settings-editor-loading/2014/5)"
+  - type: fix
+    components: [kbn]
+    text: "[Devtools not working](https://forum.readonlyrest.com/t/kibana-devtools-error-does-not-support-having-a-body/2027)"
+  - type: fix
+    components: [kbn]
+    text: "[Monitoring not working in multi-tenancy](https://forum.readonlyrest.com/t/kibana-alerting-not-working-with-readonlyrest/1986)"
+  - type: fix
+    components: [kbn]
+    text: "Regression in Kibana < 6.8.x front end crash"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x prevent navigation to hidden apps from home links"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x implicitly hide kibana:dashboard when kibana:dashboards is hidden (and viceversa)"
+  - type: fix
+    components: [kbn]
+    text: "Kibana < 7.8.x broken `clearSessionOnEvents: [tenancyHop]`"

--- a/changelog/1.37.0.yaml
+++ b/changelog/1.37.0.yaml
@@ -1,0 +1,24 @@
+version: "1.37.0"
+release_date: "2021-12-14"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797)"
+  - type: new
+    components: [es]
+    text: "New Support for 7.16.3, 7.16.2, 6.8.23, 6.8.22"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.16.3, 7.16.2, 7.16.1, 7.16.10, 6.8.23, 6.8.22, 6.8.21"
+  - type: enhancement
+    components: [es]
+    text: "fields rule handling in the context of x-Pack SQL requests"
+  - type: fix
+    components: [es]
+    text: "filter rule handling in the context of x-Pack SQL requests"
+  - type: fix
+    components: [kbn]
+    text: "POST / bulk cause an 400 error in devtools console"
+  - type: fix
+    components: [kbn]
+    text: "More robust Kibana patcher + better logs messages"

--- a/changelog/1.38.0.yaml
+++ b/changelog/1.38.0.yaml
@@ -1,0 +1,18 @@
+version: "1.38.0"
+release_date: "2022-01-17"
+entries:
+  - type: new
+    components: [es]
+    text: "New Support for 7.17.0, 7.17.1"
+  - type: new
+    components: [kbn]
+    text: "New Support for 7.17.0"
+  - type: new
+    components: [es]
+    text: "[Configuration for custom audit cluster](https://github.com/beshu-tech/readonlyrest-docs/blob/v1.38.x/elasticsearch.md#custom-audit-cluster)"
+  - type: enhancement
+    components: [es]
+    text: "Separate \"audit\" section for all audit settings"
+  - type: fix
+    components: [kbn]
+    text: "Editor rendering issue with kibana basePath enabled"

--- a/changelog/1.39.0.yaml
+++ b/changelog/1.39.0.yaml
@@ -1,0 +1,54 @@
+version: "1.39.0"
+release_date: "2022-03-19"
+entries:
+  - type: security
+    components: [kbn]
+    text: "XSS sanitize path requested"
+  - type: security
+    components: [es]
+    text: "[CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) & [CVE-2022-21653](https://nvd.nist.gov/vuln/detail/CVE-2022-21653)"
+  - type: new
+    components: [kbn]
+    text: "New Support for 8.2.0 8.1.3, 8.1.2, 8.1.1, 8.1.0, 8.0.0, 8.0.1, 7.17.3, 7.17.2"
+  - type: new
+    components: [es]
+    text: "New Support for 8.2.0, 8.1.3, 8.1.2, 8.1.1, 8.1.0, 8.0.0, 8.0.1 ([required additional patching step](https://docs.readonlyrest.com/elasticsearch#3.-patch-es))"
+  - type: new
+    components: [es]
+    text: "New Support for 7.17.3, 7.17.2"
+  - type: new
+    components: [es]
+    text: "[New `groups_and` ACL rule](https://docs.readonlyrest.com/elasticsearch#groups_and)"
+  - type: enhancement
+    components: [kbn]
+    text: "Stop inlining whitelisted headers into Authorization header"
+  - type: enhancement
+    components: [kbn]
+    text: "Log additional errors and info related to HA"
+  - type: enhancement
+    components: [kbn]
+    text: "Misc internal dependencies upgrades"
+  - type: fix
+    components: [kbn]
+    text: "Mandatory elasticsearch credentials in kibana.yml"
+  - type: fix
+    components: [kbn]
+    text: "[Reporting page redirect on refresh when kibana_hide_apps: [\"Stack Management\"]](https://forum.readonlyrest.com/t/when-hiding-stack-management-a-redirect-appears-with-report/2088)"
+  - type: fix
+    components: [kbn]
+    text: "whitelistedPaths: log errors when 404 occurs"
+  - type: fix
+    components: [kbn]
+    text: "[Issue uploading large payload](https://forum.readonlyrest.com/t/issue-uploading-large-payload/2091)"
+  - type: fix
+    components: [kbn]
+    text: "`elasticsearch.requestHeadersWhitelist` should be case insensitive"
+  - type: fix
+    components: [es]
+    text: "[Issue with handling data streams by `indices` rule](https://forum.readonlyrest.com/t/ror-1-37-0-indices-rule-and-alias-within-kibana/2078)"
+  - type: fix
+    components: [es]
+    text: "X-Pack SSL nodes cooperation with ROR SSL nodes"
+  - type: fix
+    components: [es]
+    text: "_msearch issue when filter rules was used in matched block"

--- a/changelog/1.40.0.yaml
+++ b/changelog/1.40.0.yaml
@@ -1,0 +1,52 @@
+version: "1.40.0"
+release_date: "2022-05-24"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) & [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823) & [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) & [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) &  [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) & [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518)"
+  - type: security
+    components: [kbn]
+    text: "\"Security\" app not entirely hidden in 8.2.x"
+  - type: new
+    components: [es]
+    text: "New Support for 8.2.3, 8.2.2, 8.2.1, 7.17.4"
+  - type: new
+    components: [kbn]
+    text: "New Support for 8.2.2 8.2.1, 7.17.4"
+  - type: new
+    components: [es, kbn]
+    components_raw: "ES & KBN"
+    text: "[The Impersonation feature](https://docs.readonlyrest.com/kibana#impersonation)"
+  - type: new
+    components: [es]
+    text: "[FIPS compliant SSL mode](https://docs.readonlyrest.com/elasticsearch/fips)"
+  - type: enhancement
+    components: [kbn]
+    text: "SAML cert is now required"
+  - type: enhancement
+    components: [kbn]
+    text: "moved OIDC to better library"
+  - type: enhancement
+    components: [kbn]
+    text: "OIDC jwksURL is now required"
+  - type: fix
+    components: [es]
+    text: "`indices: [\"1\"]` interpreted as integer and fails to parse"
+  - type: fix
+    components: [kbn]
+    text: "/login?jwt=xxx authorization now works again"
+  - type: fix
+    components: [kbn]
+    text: "OIDC/SAML assertion claims were not forwarded to ES"
+  - type: fix
+    components: [kbn]
+    text: "include whitelisted headers while logging"
+  - type: fix
+    components: [kbn]
+    text: "basepath handling fixes (too many redirects)"
+  - type: fix
+    components: [kbn]
+    text: "Make ROR default space the actual default one"
+  - type: fix
+    components: [kbn]
+    text: "OIDC connection error"

--- a/changelog/1.41.0.yaml
+++ b/changelog/1.41.0.yaml
@@ -1,0 +1,27 @@
+version: "1.41.0"
+release_date: "2022-06-21"
+entries:
+  - type: new
+    components: [es]
+    text: "Added `groups_and` mode to [`ror_kbn_auth`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_auth) and [`jwt_auth`](https://docs.readonlyrest.com/elasticsearch#jwt_auth) rules"
+  - type: enhancement
+    components: [kbn]
+    text: "Prevent native credentials dialogue to appear in Kibana when ES responds 401"
+  - type: enhancement
+    components: [kbn]
+    text: "Logging in after logout shows the same page you last visited"
+  - type: enhancement
+    components: [kbn]
+    text: "x-ror-correlation-id header lets you audit a whole Kibana session"
+  - type: fix
+    components: [es, kbn]
+    text: "tenancy selector didn't work well with `jwt_auth` and `ror_kbn_auth` rules"
+  - type: fix
+    components: [kbn]
+    text: "Support for special characters in tenancy names"
+  - type: fix
+    components: [kbn]
+    text: "OIDC logout flow redirecting to bad request error"
+  - type: fix
+    components: [kbn]
+    text: "OIDC connector not working in Kibana < 7.12.0"

--- a/changelog/1.42.0.yaml
+++ b/changelog/1.42.0.yaml
@@ -1,0 +1,22 @@
+version: "1.42.0"
+release_date: "2022-07-25"
+entries:
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "8.3.3, 8.3.2, 8.3.1, 8.3.0, 7.15.5 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Search box in tenancy switcher (when #tenancies > 5)"
+  - type: enhancement
+    components: [es]
+    text: "added configuration warnings in the Impersonation Feature"
+  - type: fix
+    components: [kbn]
+    text: "Logout didn't delete the SAML session on the IdP"
+  - type: fix
+    components: [kbn]
+    text: "5xx errors from Elasticsearch break Kibana users' session unrecoverably"
+  - type: fix
+    components: [es]
+    text: "ROR node cooperation with X-pack nodes"

--- a/changelog/1.43.0.yaml
+++ b/changelog/1.43.0.yaml
@@ -1,0 +1,33 @@
+version: "1.43.0"
+release_date: "2022-08-22"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.4.3, 8.4.2, 8.4.1, 8.4.0, 7.17.6 support"
+  - type: new
+    components: [es]
+    text: "8.4.3, 8.4.2, 8.4.1, 8.4.0, 7.17.6 support"
+  - type: new
+    components: [kbn]
+    text: "`kibana_custom_js_inject_file` feature"
+  - type: fix
+    components: [es]
+    text: "[`ror-tools` fix for Windows OS (patching ES 3.x issue)](https://forum.readonlyrest.com/t/ror-plugin-for-es-8-x-patch-error/2115)"
+  - type: fix
+    components: [es]
+    text: "resolving indices in the remote x-pack cluster"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:pro
+    # original: "* **🐞Fix** (KBN|PRO) ROR menu title wraps when version text is too short (cosmetic)"
+    type: fix
+    components_raw: "KBN|PRO"
+    text: "ROR menu title wraps when version text is too short (cosmetic)"
+  - type: fix
+    components: [kbn]
+    text: "infinite loading when kibana_access not defined for user"
+  - type: fix
+    components: [kbn]
+    text: "transient error with randomly choosing off range bind port on localhost"
+  - type: fix
+    components: [kbn]
+    text: "404 on login when `xpack.spaces.enabled: false`"

--- a/changelog/1.44.0.yaml
+++ b/changelog/1.44.0.yaml
@@ -1,0 +1,42 @@
+version: "1.44.0"
+release_date: "2022-10-09"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-25857](https://nvd.nist.gov/vuln/detail/CVE-2022-25857)"
+  - type: new
+    components: [kbn]
+    text: "8.5.2, 8.5.1, 8.5.0, 7.17.7 support"
+  - type: new
+    components: [es]
+    text: "8.5.2, 8.5.1, 8.5.0, 7.17.7 support"
+  - type: new
+    components: [kbn]
+    text: "**plugin packages are now [universal](https://docs.readonlyrest.com/universal-builds)**"
+  - type: new
+    components: [kbn]
+    text: "**Manage your activation keys through the [customer portal](https://readonlyrest.com/customer)**"
+  - type: new
+    components: [es]
+    text: "Added support for certificates in PEM format"
+  - type: enhancement
+    components: [kbn]
+    text: "SAML groups list duplication made header size exceed limits"
+  - type: enhancement
+    components: [kbn]
+    text: "kibana_access: admin has now privileges to manage a Kibana cluster"
+  - type: enhancement
+    components: [es]
+    text: "added distributed and persistent Test Settings & Auth Mocks configuration for the Impersonation Feature"
+  - type: enhancement
+    components: [es]
+    text: "handling high load when LDAP rules are used"
+  - type: enhancement
+    components: [es]
+    text: "`client_authentication` settings in internode SSL configuration"
+  - type: enhancement
+    components: [es]
+    text: "`acl:available_groups` dynamic variable can be used in a single value context"
+  - type: fix
+    components: [es]
+    text: "SNI handling (internode SSL)"

--- a/changelog/1.45.0.yaml
+++ b/changelog/1.45.0.yaml
@@ -1,0 +1,54 @@
+version: "1.45.0"
+release_date: "2022-11-29"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003), [CVE-2022-45146](https://nvd.nist.gov/vuln/detail/CVE-2022-45146)"
+  - type: new
+    components: [kbn]
+    text: "Activation Key API: read AK from ROR_ACTIVATION_KEY.txt"
+  - type: new
+    components: [kbn]
+    text: "Activation Key API: submit AK via POST /pkp/license (Basic auth)"
+  - type: new
+    components: [kbn]
+    text: "Inject CSS/JS files in login page"
+  - type: new
+    components: [kbn]
+    text: "Add user metadata to <body> for extra UI customization"
+  - type: new
+    components: [es]
+    text: "Added groups_and mode to [groups_provider_authorization](https://docs.readonlyrest.com/elasticsearch#groups_provider_authorization) rule"
+  - type: enhancement
+    components: [es]
+    text: "all authorization rules support wildcards in group IDs"
+  - type: enhancement
+    components: [es]
+    text: "connections in the LDAP pool should not be closed unnecessarily"
+  - type: enhancement
+    components: [kbn]
+    text: "Deterministic reporting index detection"
+  - type: enhancement
+    components: [kbn]
+    text: "Move free type impersonation to the local users area"
+  - type: enhancement
+    components: [kbn]
+    text: "don't logout when initial JWT token expires"
+  - type: fix
+    components: [kbn]
+    text: "Direct Kibana API requests not aware of kibana_index"
+  - type: fix
+    components: [kbn]
+    text: "RO and RO_strict kibana accesses"
+  - type: fix
+    components: [es]
+    text: "[when `fls_engine: es` is configured and `fields` rule is used, aggregations should be available only for allowed fields](https://forum.readonlyrest.com/t/field-level-security-and-aggregations/2133)"
+  - type: fix
+    components: [es]
+    text: "[Data streams creation issue fix](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/829)"
+  - type: fix
+    components: [es]
+    text: "Unknown structure of index settings issue fix"
+  - type: fix
+    components: [es]
+    text: "resolving index names with wildcards should take into consideration the current index state and request indices options"

--- a/changelog/1.45.1.yaml
+++ b/changelog/1.45.1.yaml
@@ -1,0 +1,12 @@
+version: "1.45.1"
+release_date: "2022-12-05"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.5.3, 7.17.8 support"
+  - type: new
+    components: [es]
+    text: "8.5.3, 7.17.8 support"
+  - type: fix
+    components: [kbn]
+    text: "ROR KBN patching script"

--- a/changelog/1.46.0.yaml
+++ b/changelog/1.46.0.yaml
@@ -1,0 +1,36 @@
+version: "1.46.0"
+release_date: "2023-01-02"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471), [CVE-2022-41915](https://nvd.nist.gov/vuln/detail/CVE-2022-41915), [CVE-2022-36944](https://nvd.nist.gov/vuln/detail/CVE-2022-36944) in [audit Scala 2.13 jar](https://mvnrepository.com/artifact/tech.beshu.ror/audit)"
+  - type: new
+    components: [kbn]
+    text: "8.6.1, 8.6.0, 7.17.9 support"
+  - type: new
+    components: [es]
+    text: "8.6.1, 8.6.0, 7.17.9 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Activation key management UI"
+  - type: enhancement
+    components: [kbn]
+    text: "Less verbose logging in info mode"
+  - type: enhancement
+    components: [kbn]
+    text: "\"Stack management\" kibana compatibility"
+  - type: fix
+    components: [kbn]
+    text: "Test settings pop up won't show"
+  - type: fix
+    components: [kbn]
+    text: "hide apps behaviour when \"Management\" is hidden"
+  - type: fix
+    components: [kbn]
+    text: "Data view with a \":\" symbol forces logout from a kibana"
+  - type: fix
+    components: [kbn]
+    text: "Session probe causes constant refresh when no `kibana_access` defined"
+  - type: fix
+    components: [es]
+    text: "large report generation using data from a remote cluster with enabled x-pack security"

--- a/changelog/1.47.0.yaml
+++ b/changelog/1.47.0.yaml
@@ -1,0 +1,36 @@
+version: "1.47.0"
+release_date: "2023-02-13"
+entries:
+  - type: security
+    components: [es]
+    text: "\"/\" endpoint was not protected for ES 8.x"
+  - type: security
+    components: [es]
+    text: "\"/_cat\" endpoint was not protected for all ES versions"
+  - type: new
+    components: [kbn]
+    text: "8.7.0, 8.6.2 support"
+  - type: new
+    components: [es]
+    text: "8.7.0, 8.6.2 support"
+  - type: new
+    components: [es]
+    text: "[the `data_streams` rule](https://docs.readonlyrest.com/v/develop/elasticsearch#data_streams)"
+  - type: enhancement
+    components: [kbn]
+    text: "optimisation in hidden apps feature"
+  - type: fix
+    components: [kbn]
+    text: "Opening index management mappings tab forces logout"
+  - type: fix
+    components: [kbn]
+    text: "Fix dark mode in the ROR menu"
+  - type: fix
+    components: [kbn]
+    text: "YAML editor updates and fixes"
+  - type: fix
+    components: [es]
+    text: "Data streams support in the `indices` rule"
+  - type: fix
+    components: [es]
+    text: "NPE when `_search` with aggregations (script) and the `fields` rule were used together"

--- a/changelog/1.48.0.yaml
+++ b/changelog/1.48.0.yaml
@@ -1,0 +1,71 @@
+version: "1.48.0"
+release_date: "2023-04-15"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2022-45688](https://nvd.nist.gov/vuln/detail/CVE-2022-45688)"
+  - type: new
+    components: [kbn]
+    text: "8.7.1, 7.17.10 support"
+  - type: new
+    components: [es]
+    text: "8.8.0, 8.7.1, 7.17.10 support"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[Introducing \"Custom Middleware\" functionality](https://docs.readonlyrest.com/kibana#custom-middleware)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[`allowed_api_paths` support in the `kibana` ACL rule](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules)"
+  - type: new
+    components: [kbn]
+    text: "Add CSRF protection in the login form"
+  - type: new
+    components: [kbn]
+    text: "Restore deprecated \"kibana.index\" support for Kibana > 8.x"
+  - type: new
+    components: [es]
+    text: "[all Kibana-related rules are gathered in one, new `kibana` ACL rule](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules)"
+  - type: new
+    components: [es]
+    text: "[audit supports a new output type: `log`](https://docs.readonlyrest.com/elasticsearch/audit)"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to disable multi-tenancy in ROR Enterprise"
+  - type: enhancement
+    components: [kbn]
+    text: "Realign index templates behaviour to the old platform"
+  - type: enhancement
+    components: [kbn]
+    text: "Error logs when SAML obtains an unusable username from the assertion"
+  - type: enhancement
+    components: [kbn]
+    text: "Test configuration warnings improvement"
+  - type: enhancement
+    components: [es]
+    text: "[Added support to override default response code for not started ROR](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/issues/794)"
+  - type: fix
+    components: [kbn]
+    text: "Security card not hidden by default"
+  - type: fix
+    components: [kbn]
+    text: "Hidden apps regex with two \"or\" operators don't hide all kibana apps"
+  - type: fix
+    components: [kbn]
+    text: "Fix Alerting Rules resulting in logout issue"
+  - type: fix
+    components: [kbn]
+    text: "Fix audit dashboard"
+  - type: fix
+    components: [kbn]
+    text: "Stop handling 500 error from `api/lens/existing_fields`"
+  - type: fix
+    components: [kbn]
+    text: "Fix lens app"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn < 7.9.x
+    # original: "* **🐞Fix** (KBN < 7.9.x) using a custom kibana index in cooperation with ROR Free"
+    type: fix
+    components_raw: "KBN < 7.9.x"
+    text: "using a custom kibana index in cooperation with ROR Free"

--- a/changelog/1.49.0.yaml
+++ b/changelog/1.49.0.yaml
@@ -1,0 +1,36 @@
+version: "1.49.0"
+release_date: "2023-05-28"
+entries:
+  - type: new
+    components: [es]
+    text: "8.8.1 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Handle `elasticsearch.serviceAccountSupport` configuration property"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to Hidden apps Stack management items hiding"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide an automated migration of tenancy indices on major Kibana version upgrade"
+  - type: enhancement
+    components: [es]
+    text: "external group ID patterns support in the external to local groups mapping"
+  - type: fix
+    components: [kbn]
+    text: "the issue with the replica number being set to 0 on tenant index creation"
+  - type: fix
+    components: [kbn]
+    text: "users won't log out from Kibana on the 500 status error"
+  - type: fix
+    components: [kbn]
+    text: "the issue with Kibana keystore not being read by the Kibana plugin"
+  - # EDGE CASE — manual review needed
+    # reason: unknown_component:kbn < 7.9.0
+    # original: "* **🐞Fix** (KBN < 7.9.0) logging issue when two Kibanas are handled by one browser at the same time"
+    type: fix
+    components_raw: "KBN < 7.9.0"
+    text: "logging issue when two Kibanas are handled by one browser at the same time"
+  - type: fix
+    components: [es]
+    text: "resolving ENVs to YAML number in ROR settings"

--- a/changelog/1.49.1.yaml
+++ b/changelog/1.49.1.yaml
@@ -1,0 +1,27 @@
+version: "1.49.1"
+release_date: "2023-06-27"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976)"
+  - type: security
+    components: [es]
+    text: "[CVE-2023-34462](https://github.com/advisories/GHSA-6mjq-h674-j845)"
+  - type: new
+    components: [kbn]
+    text: "8.8.2, 8.8.1, 8.8.0, 7.17.11 support"
+  - type: new
+    components: [es]
+    text: "8.8.2, 7.17.11 support"
+  - type: new
+    components: [es]
+    text: "[LDAP nested groups support](https://docs.readonlyrest.com/elasticsearch#ldap-connector)"
+  - type: enhancement
+    components: [kbn]
+    text: "[Allow setting default tenancy via `/login?defaultGroup` query param. To be used with \"Custom Middleware\" feature for reordering available tenancies in the ROR menu](https://docs.readonlyrest.com/examples/custom-middleware/reordering-available-tenancies)"
+  - type: fix
+    components: [es]
+    text: "[Fix for ES warnings in logs about custom action names (ROR internal actions)](https://forum.readonlyrest.com/t/invalid-action-name-cluster-ror-audit-event-put/2186)"
+  - type: fix
+    components: [es]
+    text: "[kibana access `rw` and `admin` should allow to manage component templates](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372)"

--- a/changelog/1.50.0.yaml
+++ b/changelog/1.50.0.yaml
@@ -1,0 +1,25 @@
+version: "1.50.0"
+release_date: "2023-07-25"
+entries:
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "ECK support"
+  - type: new
+    components: [kbn]
+    text: "8.9.1, 8.9.0, 7.17.12 support"
+  - type: new
+    components: [es]
+    text: "8.9.1, 8.9.0, 7.17.12 support"
+  - type: new
+    components: [kbn]
+    text: "Introduce the new ReadonlyREST API"
+  - type: enhancement
+    components: [kbn]
+    text: "Remove application item info from URL on the tenant switch to avoid a 404 not found message"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide Reordering available tenancies for proxy auth authentication"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide information about granted/rejected log-in users to debug logs"

--- a/changelog/1.51.0.yaml
+++ b/changelog/1.51.0.yaml
@@ -1,0 +1,39 @@
+version: "1.51.0"
+release_date: "2023-09-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "the issue with [api_only](https://docs.readonlyrest.com/elasticsearch#kibana-related-rules) access level user and accessing via Kibana UI"
+  - type: new
+    components: [kbn]
+    text: "8.10.2, 8.10.1, 8.9.2, 7.17.13 support"
+  - type: new
+    components: [es]
+    text: "8.10.2, 8.10.1, 8.10.0, 8.9.2, 7.17.13 support"
+  - type: new
+    components: [es]
+    text: "[Dynamic variables transformation support](https://docs.readonlyrest.com/elasticsearch#variables-functions)"
+  - type: enhancement
+    components: [kbn]
+    text: "Expose interactive Swagger as a new Security settings tab"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide detailed information about the invalid activation key"
+  - type: enhancement
+    components: [es]
+    text: "additional `hide_apps` validation in the `kibana` rule"
+  - type: fix
+    components: [kbn]
+    text: "the issue with the persistence of an activation key provided via UI when `readonlyrest_kbn.cookiePass` was not provided. The [readonlyrest_kbn.cookiePass](https://docs.readonlyrest.com/kibana#configuring-kibana) is required `kibana.yml` property"
+  - type: fix
+    components: [kbn]
+    text: "issues for Kibana versions between 7.9.0 and 7.10.2, related to the activation key, Spaces, and readonlyREST menu crash"
+  - type: fix
+    components: [kbn]
+    text: "The issue with a logout from Kibana when the link to the Kibana is open from a third-party application like `Gmail`"
+  - type: fix
+    components: [es]
+    text: "[getting data streams when not full names of backing indices are declared in the `indices` rule](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372/7)"
+  - type: fix
+    components: [es]
+    text: "stack-management screen fix in case of `xpack.security.enabled: true`"

--- a/changelog/1.51.1.yaml
+++ b/changelog/1.51.1.yaml
@@ -1,0 +1,21 @@
+version: "1.51.1"
+release_date: "2023-09-25"
+entries:
+  - type: security
+    components: [es]
+    text: "[`fields` rule didn't work well in the case of ES 7.10.0 and later and more than 10 documents in the response](https://forum.readonlyrest.com/t/field-rule-not-working-when-exceeding-a-certain-no-of-docs/2415)"
+  - type: fix
+    components: [kbn]
+    text: "issue with Observability Overview-based applications hiding"
+  - type: fix
+    components: [kbn]
+    text: "Correct `kibana.index` handling for KBN >= 7.9.0 when multi-tenancy is disabled or unavailable"
+  - type: fix
+    components: [kbn]
+    text: "Unrestricted Kibana Access on the tenancy switch when a selected tenant is not available anymore"
+  - type: fix
+    components: [kbn]
+    text: "Unhandled error during login when `multiTenancyEnabled: false`"
+  - type: fix
+    components: [es]
+    text: "LDAP connectivity improvements"

--- a/changelog/1.52.0.yaml
+++ b/changelog/1.52.0.yaml
@@ -1,0 +1,36 @@
+version: "1.52.0"
+release_date: "2023-10-09"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-4586](https://access.redhat.com/security/cve/cve-2023-4586)"
+  - type: new
+    components: [kbn]
+    text: "8.10.4, 8.10.3, 7.17.15, 7.17.14 support"
+  - type: new
+    components: [es]
+    text: "8.10.4, 8.10.3, 7.17.15, 7.17.14 support"
+  - type: new
+    components: [es]
+    text: "[New `token_authentication` rule](https://docs.readonlyrest.com/elasticsearch#token_authentication)"
+  - type: enhancement
+    components: [kbn]
+    text: "Permanently hide Kibana|ES features that are impossible to support"
+  - type: enhancement
+    components: [kbn]
+    text: "[License expiration reminder](https://forum.readonlyrest.com/t/license-expiration-reminder/2417)"
+  - type: enhancement
+    components: [kbn]
+    text: "Make `kibana.index` setting from kibana.yml an invalid property for an Enterprise user"
+  - type: fix
+    components: [kbn]
+    text: "Issue with not adding `elasticsearch.customHeaders` setting from kibana.yml to ROR requests"
+  - type: fix
+    components: [kbn]
+    text: "Logout after opening Stack management Upgrading assistant"
+  - type: fix
+    components: [kbn]
+    text: "Problem with logging in of two users in two tabs when two Kibana instances are used"
+  - type: fix
+    components: [kbn]
+    text: "Problem with logging in when multi-tenancy is enabled and the `indices` rule is defined in the ROR settings"

--- a/changelog/1.53.0.yaml
+++ b/changelog/1.53.0.yaml
@@ -1,0 +1,36 @@
+version: "1.53.0"
+release_date: "2023-11-20"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-4586](https://nvd.nist.gov/vuln/detail/CVE-2023-4586), [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072)"
+  - type: new
+    components: [kbn]
+    text: "8.11.3, 8.11.2, 8.11.1, 8.11.0, 7.17.16 support"
+  - type: new
+    components: [es]
+    text: "8.11.3, 8.11.2, 8.11.1, 8.11.0, 7.17.16 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide Activate license endpoint to the ReadonlyREST API"
+  - type: enhancement
+    components: [es]
+    text: "[when the `kibana` rule and the `indices` rule are defined in the same block](https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#index), there is no need to explicitly allow kibana-related indices"
+  - type: fix
+    components: [kbn]
+    text: "problem with reports generation when `kibana.index` in kibana.yml is used"
+  - type: fix
+    components: [kbn]
+    text: "crash loop during license service initialization"
+  - type: fix
+    components: [kbn]
+    text: "problem with logging in in KBN 7.17.13 (and above) and 8.10.4 (and above) when deployed using ECK"
+  - type: fix
+    components: [kbn]
+    text: "[problem with multi-tenancy and ECK](https://forum.readonlyrest.com/t/multi-tanancy-issue/2427)"
+  - type: fix
+    components: [kbn]
+    text: "problem with forbidden `/_create/config` response on Login to the Kibana"
+  - type: fix
+    components: [es]
+    text: "[patching fix, when a non-default ES path is used (e.g. on K8s)](https://forum.readonlyrest.com/t/getting-java-lang-illegalargumentexception-when-initializing-ror-in-es-8-10-4/2441)"

--- a/changelog/1.54.0.yaml
+++ b/changelog/1.54.0.yaml
@@ -1,0 +1,27 @@
+version: "1.54.0"
+release_date: "2023-12-17"
+entries:
+  - type: security
+    components: [es]
+    text: "[Scroll API: protected data could leak when the `fields` rule was used with `fls_engine` set to `es` or `es_with_lucene`](https://forum.readonlyrest.com/t/field-rule-not-working-when-exceeding-a-certain-no-of-docs/2415/7)"
+  - type: new
+    components: [kbn]
+    text: "8.12.0, 8.11.4 support"
+  - type: new
+    components: [es]
+    text: "8.12.0, 8.11.4, 7.17.17 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide automatic [cleaning of stale sessions](https://docs.readonlyrest.com/kibana#automatic-session-cleanup)"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide automatic cleaning of stale CSRF cookies"
+  - type: fix
+    components: [kbn]
+    text: "Adjust the ROR API POST license endpoint body to the contract to respect the `license` body parameter instead of a `token`"
+  - type: fix
+    components: [kbn]
+    text: "`CorelationId`` is changed on every session refresh"
+  - type: fix
+    components: [es]
+    text: "[\"missing authorization info\" problem in some situations when `xpack.security.enabled` was configured to be `true`](https://forum.readonlyrest.com/t/diana-eck/2298/75)"

--- a/changelog/1.55.0.yaml
+++ b/changelog/1.55.0.yaml
@@ -1,0 +1,30 @@
+version: "1.55.0"
+release_date: "2024-01-29"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2023-51074](https://nvd.nist.gov/vuln/detail/CVE-2023-51074)"
+  - type: new
+    components: [kbn]
+    text: "8.12.2 ,8.12.1, 7.17.18, 7.17.17 support"
+  - type: new
+    components: [es]
+    text: "8.12.2, 8.12.1, 7.17.18 support"
+  - type: new
+    components: [es]
+    text: "[Elasticsearch images with preinstalled ReadonlyREST plugin in Docker Hub](https://hub.docker.com/r/beshultd/elasticsearch-readonlyrest)"
+  - type: enhancement
+    components: [kbn]
+    text: "Optional `readonlyrest_kbn.auth.oidc_kc.proxyURL` kibana.yml configuration for the OIDC connection which allows declaring your proxy URL"
+  - type: enhancement
+    components: [kbn]
+    text: "Upon successful activation and edition changes all sessions are cleared and users are logged out"
+  - type: fix
+    components: [kbn]
+    text: "Saved objects are not visible for the users on Kibana >= 8.8.0"
+  - type: fix
+    components: [es]
+    text: "[LDAP nested group IDs are properly escaped](https://forum.readonlyrest.com/t/support-kbn-ent-ldap-and-parentheses/2466)"
+  - type: fix
+    components: [es]
+    text: "Logout when a user with restricted `kibana.access` tried to see a restoration status of snapshots in Kibana"

--- a/changelog/1.56.0.yaml
+++ b/changelog/1.56.0.yaml
@@ -1,0 +1,48 @@
+version: "1.56.0"
+release_date: "2024-03-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "Provide a way to switch light/dark mode per user"
+  - type: new
+    components: [kbn]
+    text: "8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support"
+  - type: new
+    components: [es]
+    text: "8.13.2, 8.13.1, 8.13.0, 7.17.20, 7.17.19 support"
+  - type: warning
+    components: [es]
+    text: "[for ES > 6.5 patching is required since this version of ROR](https://docs.readonlyrest.com/elasticsearch#id-5.-patch-elasticsearch)"
+  - type: enhancement
+    components: [kbn]
+    text: "The activation key will be revalidated in the interval"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide a way to define Activation key [retrieval mode](https://docs.readonlyrest.com/v/develop/universal-builds#change-activation-key-retrieval-mode-via-kibana.yml)"
+  - type: fix
+    components: [kbn]
+    text: "Sometimes reports are not generated correctly for Kibana >= 8.0.0 and \"Max attempt reached\" error  appears"
+  - type: fix
+    components: [kbn]
+    text: "The OIDC scope configuration property was not applied and the default configuration was used instead."
+  - type: fix
+    components: [kbn]
+    text: "The OIDC proxy parameter was not handled properly in case of HTTPs connection over HTTP proxy server"
+  - type: fix
+    components: [kbn]
+    text: "Missing information when Kibana is not patched"
+  - type: fix
+    components: [es]
+    text: "[Repositories and Snapshots handling by ES coordinating nodes](https://forum.readonlyrest.com/t/snapshot-status-cannot-modify-incoming-request/2471)"
+  - type: fix
+    components: [es]
+    text: "[Internode SSL `certificate_verification: true` was causing problems with nodes discovery](https://forum.readonlyrest.com/t/upgrade-elasticsearch-8-2-to-8-x-leads-to-ssl-problems/2480)"
+  - type: fix
+    components: [es]
+    text: "Missing `x-elastic-product` header in the response when `fields` and `filter` rules were used"
+  - type: fix
+    components: [es]
+    text: "Proper `forbid` policy handling during processing ROR login request"
+  - type: fix
+    components: [es]
+    text: "`application/nd-json` media type handling (in case of ES `7.x` versions)"

--- a/changelog/1.57.0.yaml
+++ b/changelog/1.57.0.yaml
@@ -1,0 +1,55 @@
+version: "1.57.0"
+release_date: "2024-04-28"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-29025](https://nvd.nist.gov/vuln/detail/CVE-2024-29025)"
+  - type: new
+    components: [es]
+    text: "[LDAP Connector](https://docs.readonlyrest.com/elasticsearch#configuration-notes) feature: groups server-side filtering"
+  - type: new
+    components: [es]
+    text: "[LDAP Connector](https://docs.readonlyrest.com/elasticsearch#configuration-notes) feature: skip user search option when user attribute is `cn`"
+  - type: warning
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "Internal API incompatibilities (to take advantage of rolling update capabilities, upgrade ROR KBN first)"
+  - type: warning
+    components: [es]
+    text: "Support for ES < 6.8.0 was dropped"
+  - type: enhancement
+    components: [kbn]
+    text: "User settings available for all access type users"
+  - type: enhancement
+    components: [kbn]
+    text: "Add option to change the Default Route and Time zone in User settings"
+  - type: enhancement
+    components: [kbn]
+    text: "Provide correlation ID to Kibana logs"
+  - type: enhancement
+    components: [es]
+    text: "Rich, context-based debug logging in the LDAP connector and LDAP-related rules"
+  - type: enhancement
+    components: [es]
+    text: "Additional [validations](https://docs.readonlyrest.com/elasticsearch#configuring-an-acl-with-filter-fields-rules-when-using-kibana): `kibana` rule should not be used with some other rules in the same block"
+  - type: fix
+    components: [kbn]
+    text: "Sometimes reports are not generated correctly for Kibana < 8.0.0 and the \"Max attempt reached\" error appears"
+  - type: fix
+    components: [kbn]
+    text: "Adjust interactive API swagger dark mode colors"
+  - type: fix
+    components: [kbn]
+    text: "CSRF problem when multiple ECK Kibana instances"
+  - type: fix
+    components: [kbn]
+    text: "Plugin doesn't run for a version Kibana < 7.11.0 when the OIDC proxy is enabled"
+  - type: fix
+    components: [kbn]
+    text: "Session probe should log out the user when empty metadata was returned from ES ROR"
+  - type: fix
+    components: [es]
+    text: "Misc issues when `xpack.security.enabled: true` is set"
+  - type: fix
+    components: [es]
+    text: "Patched files permission issue"

--- a/changelog/1.57.1.yaml
+++ b/changelog/1.57.1.yaml
@@ -1,0 +1,6 @@
+version: "1.57.1"
+release_date: "2024-04-29"
+entries:
+  - type: fix
+    components: [es]
+    text: "configuration parsing regression: one group definition can be a string"

--- a/changelog/1.57.2.yaml
+++ b/changelog/1.57.2.yaml
@@ -1,0 +1,21 @@
+version: "1.57.2"
+release_date: "2024-05-05"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.13.4, 8.13.3, 7.17.21 support"
+  - type: new
+    components: [es]
+    text: "8.13.4, 8.13.3, 7.17.21 support"
+  - type: fix
+    components: [kbn]
+    text: "Kibana <= 7.2.1 doesn't run"
+  - type: fix
+    components: [kbn]
+    text: "Provides a way to migrate an existing session index to the new session"
+  - type: fix
+    components: [es]
+    text: "[Patching issue for Elasticsearch installed from packages](https://forum.readonlyrest.com/t/bootstrap-error-es/2574)"
+  - type: fix
+    components: [es]
+    text: "Patching issue for Elasticsearch OSS versions"

--- a/changelog/1.57.3.yaml
+++ b/changelog/1.57.3.yaml
@@ -1,0 +1,18 @@
+version: "1.57.3"
+release_date: "2024-05-18"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-34447](https://nvd.nist.gov/vuln/detail/CVE-2024-34447)"
+  - type: new
+    components: [kbn]
+    text: "8.14.1, 8.14.0, 7.17.22 support"
+  - type: new
+    components: [es]
+    text: "8.14.1, 8.14.0, 7.17.22 support"
+  - type: fix
+    components: [kbn]
+    text: "The CSRF cookie name issue that caused the \"Wrong credentials\" error during login"
+  - type: fix
+    components: [kbn]
+    text: "Automatic migration issue for Kibana >= 8.8.0 that caused the \"mapping set to strict, dynamic introduction of... error"

--- a/changelog/1.58.0.yaml
+++ b/changelog/1.58.0.yaml
@@ -1,0 +1,36 @@
+version: "1.58.0"
+release_date: "2024-06-30"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2022-39353](https://www.cve.org/CVERecord?id=CVE-2022-39353), [CVE-2020-7753](https://www.cve.org/CVERecord?id=CVE-2020-7753), [CVE-2022-37616](https://www.cve.org/CVERecord?id=CVE-2022-37616), [CVE-2024-29041](https://www.cve.org/CVERecord?id=CVE-2024-29041), [CVE-2022-0691](https://www.cve.org/CVERecord?id=CVE-2022-0691), [CVE-2021-3801](https://www.cve.org/CVERecord?id=CVE-2021-3801), [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883), [CVE-2022-0512](https://www.cve.org/CVERecord?id=CVE-2022-0512), [CVE-2022-0686](https://www.cve.org/CVERecord?id=CVE-2022-0686), [CVE-2022-0639](https://www.cve.org/CVERecord?id=CVE-2022-0639), [CVE-2022-25881](https://www.cve.org/CVERecord?id=CVE-2022-25881), [CVE-2023-0842](https://www.cve.org/CVERecord?id=CVE-2023-0842), [CVE-2017-16137](https://www.cve.org/CVERecord?id=CVE-2017-16137), [CVE-2022-33987](https://www.cve.org/CVERecord?id=CVE-2022-33987), [CVE-2022-23647](https://www.cve.org/CVERecord?id=CVE-2022-23647), [CVE-2022-36083](https://www.cve.org/CVERecord?id=CVE-2022-36083), [CVE-2024-28176](https://www.cve.org/CVERecord?id=CVE-2024-28176)"
+  - type: new
+    components: [kbn]
+    text: "[Kibana images with preinstalled ReadonlyREST plugin in Docker Hub](https://hub.docker.com/r/beshultd/kibana-readonlyrest)"
+  - type: new
+    components: [kbn]
+    text: "8.14.3, 8.14.2 support"
+  - type: new
+    components: [es]
+    text: "8.14.3, 8.14.2 support"
+  - type: new
+    components: [es]
+    text: "[\"structured groups\" feature](https://github.com/beshu-tech/readonlyrest-docs/blob/develop/details/structured-groups.md) (authorization rules group names and group IDs can be defined separately)"
+  - type: enhancement
+    components: [kbn]
+    text: "New `readonlyrest_kbn.cookies.secure` and `readonlyrest_kbn.cookies.sameSite` cookie settings via kibana.yml"
+  - type: enhancement
+    components: [es]
+    text: "improved error logging on the creation of LDAP connectors"
+  - type: enhancement
+    components: [es]
+    text: "Patcher - invalid state after patching detection improvements"
+  - type: fix
+    components: [kbn]
+    text: "Impersonation and session probe logout issue"
+  - type: fix
+    components: [kbn]
+    text: "[Problem with the number of replicas and index template, where the number of replicas was always set to 1. Now, the default value will be the same, as in the case of the Kibana index](https://forum.readonlyrest.com/t/0-replicas-for-single-node-clusters/2530)"
+  - type: fix
+    components: [kbn]
+    text: "Fix problem with multi-tenancy features when xpack.security.enabled: true"

--- a/changelog/1.59.0.yaml
+++ b/changelog/1.59.0.yaml
@@ -1,0 +1,24 @@
+version: "1.59.0"
+release_date: "2024-08-01"
+entries:
+  - type: new
+    components: [es]
+    text: "8.15.1, 8.15.0, 7.17.24, 7.17.23, 6.7.x support"
+  - type: new
+    components: [kbn]
+    text: "8.15.1, 8.15.0, 7.17.24, 7.17.23 support"
+  - type: enhancement
+    components: [kbn]
+    text: "Replace a broken Alert and Connectors applications with the link to our [new tool](https://anaphora.it) for Reports and alerting for Kibana > 8.6.0 (edited)"
+  - type: fix
+    components: [kbn]
+    text: "Handling reporting URL for report generation"
+  - type: fix
+    components: [kbn]
+    text: "Embedding with inline JWT is a feature available only in ReadonlyREST PRO and Enterprise"
+  - type: fix
+    components: [es]
+    text: "[Patcher `UnsupportedOperationException` issue on Windows](https://forum.readonlyrest.com/t/ror-1-58-0-for-es8-14-3-windows-setup/2577)"
+  - type: fix
+    components: [es]
+    text: "for the problem with `_async_search` on ES 8.14.x"

--- a/changelog/1.60.0.yaml
+++ b/changelog/1.60.0.yaml
@@ -1,0 +1,40 @@
+version: "1.60.0"
+release_date: "2024-09-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "8.15.3, 8.15.2, 7.17.25 support"
+  - type: new
+    components: [es]
+    text: "8.15.3, 8.15.2, 7.17.25 support"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN|ES"
+    text: "[ECK support documentation](https://docs.readonlyrest.com/eck)"
+  - type: new
+    components: [es]
+    text: "configurable ROR YAML settings max size"
+  - type: warning
+    components: [es]
+    text: "The prompt for basic authorization is disabled by default. To keep the previous behavior, set `readonlyrest.prompt_for_basic_auth` to `true` in the ROR configuration"
+  - type: enhancement
+    components: [kbn]
+    text: "There is an option to define [client authentication methods](https://docs.readonlyrest.com/kibana#client-authentication-methods) in the `kibana.yml` via `readonlyrest_kbn.auth.<YOUR_OIDC_CONFIG>.tokenEndpointAuthMethod`, 'client_secret_post' or ''client_secret_basic'"
+  - type: enhancement
+    components: [kbn]
+    text: "Stop Kibana when enabled features are not available"
+  - type: fix
+    components: [kbn]
+    text: "HTTP 400 (bad request) issue when there is a Nginx proxy server between es and Kibana"
+  - type: fix
+    components: [kbn]
+    text: "Fix for the problem with correctly hiding Management features `ROR Manage Kibana` defined in the readonlyrest.yml `kibana_hide_apps` property"
+  - type: fix
+    components: [es]
+    text: "ROR KBN docker image: passing ROR settings as ENVs fixes"
+  - type: fix
+    components: [es]
+    text: "[Data stream backing indices access issue with the indices rule](https://forum.readonlyrest.com/t/requested-index-doesnt-exist/2573)"
+  - type: fix
+    components: [es]
+    text: "[Fix for the problem with remote access to data stream aliases](https://forum.readonlyrest.com/t/requested-index-doesnt-exist/2573)"

--- a/changelog/1.61.0.yaml
+++ b/changelog/1.61.0.yaml
@@ -1,0 +1,57 @@
+version: "1.61.0"
+release_date: "2024-11-12"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764)"
+  - type: warning
+    components: [kbn]
+    text: "Acknowledgement needs to be accepted before a Kibana patching process. For scripts, you can [set a flag](https://docs.readonlyrest.com/kibana#patching-kibana) to automate a process (edited)"
+  - type: new
+    components: [kbn]
+    text: "8.15.4 support"
+  - type: new
+    components: [es]
+    text: "8.16.0, 8.15.4 support"
+  - type: new
+    components: [es]
+    text: "There is an option to define [a custom response for users in ACL block with the 'forbid' policy](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration)"
+  - type: enhancement
+    components: [kbn]
+    text: "Set-Cookie is not returned with KBN API response"
+  - type: enhancement
+    components: [kbn]
+    text: "Reduce the amount of ReadonlyREST session updates"
+  - type: enhancement
+    components: [kbn]
+    text: "Kibana plugin won't start until the connection with Elasticsearch is established"
+  - type: enhancement
+    components: [kbn]
+    text: "API and activation key tabs in the Security settings are visible only for the admin or unrestricted access users"
+  - type: enhancement
+    components: [kbn]
+    text: "detecting issues related to high disk watermark warning"
+  - type: enhancement
+    components: [kbn]
+    text: "License expiration info only for admin and unrestricted access users"
+  - type: enhancement
+    components: [es]
+    text: "index exclusion (dash) syntax support"
+  - type: fix
+    components: [kbn]
+    text: "Don't stop Kibana when correlationId is not available in the session"
+  - type: fix
+    components: [kbn]
+    text: "Provide additional [SAML configuration options](https://docs.readonlyrest.com/kibana#usage-with-active-directory-federation-services) to handle Active Directory Federation Services (ADFS) properly"
+  - type: fix
+    components: [kbn]
+    text: "login page customization should be a PRO feature instead of an Enterprise"
+  - type: fix
+    components: [kbn]
+    text: "Logging to file doesn't work for Kibana 8.x"
+  - type: fix
+    components: [es]
+    text: "Snapshot Status API - forbidden response while checking the status of all snapshots of the given repository"
+  - type: fix
+    components: [es]
+    text: "Snapshot API - misc issues for ES 6.x"

--- a/changelog/1.61.1.yaml
+++ b/changelog/1.61.1.yaml
@@ -1,0 +1,24 @@
+version: "1.61.1"
+release_date: "2024-11-20"
+entries:
+  - type: security
+    components: [es]
+    text: "[Data leak through the ESQL API](https://forum.readonlyrest.com/t/eql-requests-returns-data-even-though-they-aren-t-allowed/2679) (for ES >= 8.11.0)"
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-21538](https://www.cve.org/CVERecord?id=CVE-2024-21538), [CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-47535](https://nvd.nist.gov/vuln/detail/CVE-2024-47535)"
+  - type: new
+    components: [kbn]
+    text: "8.17.0, 8.16.2, 8.16.1, 8.16.0, 8.15.5, 7.17.27, 7.17.26 support"
+  - type: new
+    components: [es]
+    text: "8.17.0, 8.16.2, 8.16.1, 8.15.5, 7.17.27, 7.17.26 support"
+  - type: new
+    components: [es]
+    text: "ESQL support"
+  - type: fix
+    components: [kbn]
+    text: "Elasticsearch red status shouldn't kill the Kibana process on initialization"

--- a/changelog/1.62.0.yaml
+++ b/changelog/1.62.0.yaml
@@ -1,0 +1,48 @@
+version: "1.62.0"
+release_date: "2025-01-24"
+entries:
+  - type: security
+    components: [es]
+    text: "[CVE-2024-53990](https://nvd.nist.gov/vuln/detail/CVE-2024-53990)"
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-21538](https://www.cve.org/CVERecord?id=CVE-2024-21538), [CVE-2024-47764](https://www.cve.org/CVERecord?id=CVE-2024-47764), [CVE-2024-52798](https://www.cve.org/CVERecord?id=CVE-2024-52798)"
+  - type: warning
+    components: [kbn]
+    text: "Updated [`readonlyrest_kbn: license: activationKeyRefreshInterval`](https://forum.readonlyrest.com/t/restricting-access-to-some-spaces/2633/4) - the maximum refresh interval is now set to 1 day."
+  - type: new
+    components: [es, kbn]
+    text: "Introduced support for [Elastic APM (Application Performance Monitoring)](https://www.elastic.co/observability/application-performance-monitoring)."
+  - type: new
+    components: [kbn]
+    text: "8.17.3, 8.17.2, 8.17.1, 8.16.5, 8.16.4, 8.16.3, 7.17.28 support"
+  - type: new
+    components: [es]
+    text: "8.17.3, 8.17.2, 8.17.1, 8.16.5, 8.16.4, 8.16.3, 7.17.28 support"
+  - type: new
+    components: [kbn]
+    text: "Added [Kibana images with the preinstalled ReadonlyREST plugin for the arm64 platform](https://hub.docker.com/r/beshultd/kibana-readonlyrest) on Docker Hub."
+  - type: new
+    components: [es]
+    text: "Added [Elasticsearch images with the preinstalled ReadonlyREST plugin for the arm64 platform](https://hub.docker.com/r/beshultd/elasticsearch-readonlyrest) on Docker Hub."
+  - type: enhancement
+    components: [es]
+    text: "[Introduced validation to prevent multiple username entries in the users section.](https://forum.readonlyrest.com/t/ror-1-57-3-es-8-13-2-double-usernames-allowed/2621/2)"
+  - type: fix
+    components: [kbn]
+    text: "[Resolved an issue with exit patching-based commands.](https://forum.readonlyrest.com/t/restricting-access-to-some-spaces/2633/6)"
+  - type: fix
+    components: [kbn]
+    text: "Addressed a bug in Kibana 8.16.0 and later versions to hide the permissions tab in a space."
+  - type: fix
+    components: [kbn]
+    text: "Fixed a compatibility issue where OIDC and SAML didn't work in Kibana versions earlier than 7.11.0."
+  - type: fix
+    components: [kbn]
+    text: "Ensured user settings are overridden only for the default space."
+  - type: fix
+    components: [es]
+    text: "Relaxed restrictions on snapshot restoration during index checks."
+  - type: fix
+    components: [es]
+    text: "Resolved issue with Stack Monitoring access when `xpack.security.enabled: true` is configured."

--- a/changelog/1.63.0.yaml
+++ b/changelog/1.63.0.yaml
@@ -1,0 +1,54 @@
+version: "1.63.0"
+release_date: "2025-03-12"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-26791](https://www.cve.org/CVERecord?id=CVE-2025-26791), [CWE-772](https://cwe.mitre.org/data/definitions/772.html)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-57699](https://nvd.nist.gov/vuln/detail/CVE-2024-53990) [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) [CVE-2025-24970](https://nvd.nist.gov/vuln/detail/CVE-2025-24970)"
+  - type: new
+    components: [kbn]
+    text: "9.0.1, 9.0.0, 9.0.0-rc1, 9.0.0-beta1, 8.18.1, 8.18.0, 8.17.6, 8.17.5, 8.17.4, 8.16.6 support"
+  - type: new
+    components: [es]
+    text: "9.0.1, 9.0.0, 9.0.0-rc1, 9.0.0-beta1, 8.18.1, 8.18.0, 8.17.6, 8.17.5, 8.17.4, 8.16.6 support"
+  - type: new
+    components: [es]
+    text: "[Added `groups_not_any_of` and `groups_not_all_of` rules](https://forum.readonlyrest.com/t/support-kbn-ent-managing-forbidden-messages/2623)"
+  - type: new
+    components: [es]
+    text: "[New unified and simplified syntax for groups rules](https://docs.readonlyrest.com/elasticsearch#groups-rules)"
+  - type: enhancement
+    components: [kbn]
+    text: "For Kibana >= 8.14.0: Added backward compatibility to hide the Dashboard app by declaring Analytics|Dashboard and Analytics|Dashboards in the `kibana.hide_apps` rule"
+  - type: enhancement
+    components: [kbn]
+    text: "Added information about skipping patching confirmation prompt to the patching helper"
+  - type: enhancement
+    components: [kbn]
+    text: "[When Kibana is opened in multiple browser tabs, logging into Kibana in one tab automatically logs in all browser tabs]"
+  - type: fix
+    components: [kbn]
+    text: "Don't terminate Kibana when disk reaches low watermark"
+  - type: fix
+    components: [kbn]
+    text: "For Kibana >= 8.15.0: Added support for reporting data stream multitenancy"
+  - type: fix
+    components: [kbn]
+    text: "Silenced \"Error fetching fields for index pattern\" toast messages due to forbidden response in Kibana Dashboard and Discover page"
+  - type: fix
+    components: [kbn]
+    text: "For Kibana >= 8.17.0: Fixed Elasticsearch navigation header being visible when `kibana.hide_apps: [ \"Elasticsearch\" ]`"
+  - type: fix
+    components: [kbn]
+    text: "[For Kibana >= 8.5.0: Fixed Dev tools play buttons not being visible for RO users](https://forum.readonlyrest.com/t/ldap-multitenancy-with-no-group-name-to-index-name-relation/2742/8)"
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with hiding the dashboard app when using regular expressions in the kibana_hide_apps field"
+  - type: fix
+    components: [es]
+    text: "Fixed various issues with restoring snapshot API"
+  - type: fix
+    components: [es]
+    text: "Fixed data streams, index, and component templates being forbidden for RW users in stack management"

--- a/changelog/1.64.0.yaml
+++ b/changelog/1.64.0.yaml
@@ -1,0 +1,48 @@
+version: "1.64.0"
+release_date: "2025-05-11"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-53382](https://nvd.nist.gov/vuln/detail/CVE-2024-53382), [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789), [CVE-2025-29774](https://www.cve.org/CVERecord?id=CVE-2025-29774)"
+  - type: security
+    components: [es]
+    text: "[CVE-2023-3894](https://nvd.nist.gov/vuln/detail/CVE-2023-3894), [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193)"
+  - type: warning
+    components: [es]
+    text: "Acknowledgement needs to be accepted before the Elasticsearch patching process. For scripts, you can [set the flag](https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch) to automate the process."
+  - type: new
+    components: [kbn]
+    text: "Added an endpoint to retrieve all user tenancies via the ReadonlyREST API. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/User's%20tenants/get_api_ror_user_tenants) for usage details."
+  - type: new
+    components: [kbn]
+    text: "Introduced support for passing `x-ror-tenancy-id` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details."
+  - type: new
+    components: [kbn]
+    text: "Introduced support for passing `x-ror-impersonating` in direct Kibana requests. See the [ReadonlyREST API Documentation](https://portal.readonlyrest.com/docs/swagger/master#/Example%20ReadonlyREST%20headers%20usage%20with%20Kibana%20API/get_api__) for details."
+  - type: enhancement
+    components: [kbn]
+    text: "Retains the currently selected group information after user logout. This setting is user-configurable and disabled by default."
+  - type: enhancement
+    components: [kbn]
+    text: "Displays [detailed \"reason\" messages from the ROR Elasticsearch](https://docs.readonlyrest.com/elasticsearch#unauthorized-response-configuration) response in the login form instead of a generic \"Wrong credentials\" message."
+  - type: enhancement
+    components: [kbn]
+    text: "Added support for passing additional [SAML](https://docs.readonlyrest.com/kibana#additional-parameters) and [OIDC](https://docs.readonlyrest.com/kibana#additional-parameters) config parameters via `kibana.yml`."
+  - type: enhancement
+    components: [kbn]
+    text: "Adjusted ReadonlyREST plugin UI styles for compatibility with Kibana 9.x."
+  - type: enhancement
+    components: [es]
+    text: "Username duplication check in the \"users\" section of ROR ES settings can [be optionally disabled](https://docs.readonlyrest.com/elasticsearch#users_section_duplicate_usernames_detection)."
+  - type: enhancement
+    components: [es]
+    text: "Added support for [`readonlyrest.global_settings`](https://docs.readonlyrest.com/elasticsearch#global-settings) in Elasticsearch ROR settings."
+  - type: fix
+    components: [kbn]
+    text: "Resolved an unhandled error when `logging.root.level` is set to `all` in `kibana.yml`."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with retrieving username and group information in AFDS OIDC."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue with passing `x-ror-correlation-id` to the ReadonlyREST API request."

--- a/changelog/1.64.1.yaml
+++ b/changelog/1.64.1.yaml
@@ -1,0 +1,6 @@
+version: "1.64.1"
+release_date: "2025-05-13"
+entries:
+  - type: fix
+    components: [es]
+    text: "Correct patching verification in ROR Docker image entrypoint"

--- a/changelog/1.64.2.yaml
+++ b/changelog/1.64.2.yaml
@@ -1,0 +1,12 @@
+version: "1.64.2"
+release_date: "2025-05-17"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support"
+  - type: new
+    components: [es]
+    text: "9.0.3, 9.0.2, 8.18.3, 8.18.2, 8.17.8, 8.17.7, 7.17.29 support"
+  - type: fix
+    components: [es]
+    text: "[Fixed an issue with Elasticsearch patching process on Windows operating systems](https://forum.readonlyrest.com/t/ror-1-64-0-for-es9-0-1-windows-setup/2778)"

--- a/changelog/1.65.0.yaml
+++ b/changelog/1.65.0.yaml
@@ -1,0 +1,51 @@
+version: "1.65.0"
+release_date: "2025-07-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-5889](https://nvd.nist.gov/vuln/detail/CVE-2025-5889)"
+  - type: security
+    components: [es]
+    text: "[CVE-2024-29857](https://nvd.nist.gov/vuln/detail/cve-2024-29857) (when FIPS SSL is used)"
+  - type: new
+    components: [kbn]
+    text: "Added support for configuring [JSON log format](https://www.elastic.co/docs/troubleshoot/kibana/using-kibana-server-logs) in `kibana.yml`."
+  - type: new
+    components: [es]
+    text: "[Added support for a new output type: `data_stream` in audit logging](https://docs.readonlyrest.com/elasticsearch/audit#configuration)."
+  - type: new
+    components: [es]
+    text: "Included Elasticsearch node name and cluster name in the audit reports."
+  - type: enhancement
+    components: [kbn]
+    text: "Logged detailed messages when the CSRF token has expired."
+  - type: enhancement
+    components: [kbn]
+    text: "[Added `id_token` as a valid option for `userInfoSource`](https://docs.readonlyrest.com/kibana#user-info-source-methods)."
+  - type: enhancement
+    components: [es]
+    text: "Improved handling of JVM properties related to ROR settings."
+  - type: fix
+    components: [kbn]
+    text: "Fixed OIDC logout redirection issue by switching `redirect_uri` to `id_token_hint` and using `post_logout_redirect_uri`."
+  - type: fix
+    components: [kbn]
+    text: "The ReadonlyREST Kibana plugin now accepts custom appender names defined in `kibana.yml`."
+  - type: fix
+    components: [kbn]
+    text: "When \"Remember Group After Logout\" is enabled, groups without access are correctly ignored during login."
+  - type: fix
+    components: [kbn]
+    text: "Fixed issue where the Kibana index template was not applied for Kibana versions ≥ 8.8.0."
+  - type: fix
+    components: [kbn]
+    text: "Resolved a bug with `readonlyrest_kbn.resetKibanaIndexToTemplate: true` for Kibana 7.x."
+  - type: fix
+    components: [kbn]
+    text: "Fixed an issue where a custom session index name was not respected after Kibana restart."
+  - type: fix
+    components: [es]
+    text: "Fixed an issue preventing snapshots from being restored when no indices were specified."
+  - type: fix
+    components: [es]
+    text: "File ownership and permissions are now preserved during `ror-tools` patch and unpatch operations."

--- a/changelog/1.65.1.yaml
+++ b/changelog/1.65.1.yaml
@@ -1,0 +1,15 @@
+version: "1.65.1"
+release_date: "2025-07-15"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support"
+  - type: new
+    components: [es]
+    text: "9.1.1, 9.1.0, 9.0.5, 9.0.4, 8.19.2, 8.19.1, 8.19.0, 8.18.5, 8.18.4, 8.17.10, 8.17.9 support"
+  - type: new
+    components: [eck]
+    text: "3.1.0 support"
+  - type: fix
+    components: [es]
+    text: "Docker images now start correctly when `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING` is set."

--- a/changelog/1.66.0.yaml
+++ b/changelog/1.66.0.yaml
@@ -1,0 +1,42 @@
+version: "1.66.0"
+release_date: "2025-08-28"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-7339](https://nvd.nist.gov/vuln/detail/CVE-2025-7339), [CVE-2025-7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783), [CVE-2025-54419](https://nvd.nist.gov/vuln/detail/CVE-2025-54419), [CVE-2025-9288](https://nvd.nist.gov/vuln/detail/CVE-2025-9288)"
+  - type: security
+    components: [kbn]
+    text: "[Prevented visibility of hidden functions through Kibana UI search](https://forum.readonlyrest.com/t/hidden-functions-are-available-through-the-search/2840/2)"
+  - type: security
+    components: [es]
+    text: "Removed internal failure details from error responses to prevent unintended information disclosure"
+  - type: new
+    components: [kbn]
+    text: "9.1.3, 9.1.2, 9.0.6, 8.19.3, 8.18.6 support"
+  - type: new
+    components: [es]
+    text: "9.1.3, 9.1.2, 9.0.6, 8.19.3, 8.18.6 support"
+  - type: enhancement
+    components: [es]
+    text: "Refined user metadata selection logic during login to prioritize matched blocks associated with a defined Kibana index"
+  - type: enhancement
+    components: [es]
+    text: "Patching: improved handling of the consent flag when provided via environment variables for more reliable configuration"
+  - type: fix
+    components: [kbn]
+    text: "Resolved issue with index deletion in **Index Management** via Kibana UI"
+  - type: fix
+    components: [kbn]
+    text: "Corrected document display in **Discover** when indices are defined in the user ACL block"
+  - type: fix
+    components: [kbn]
+    text: "Fixed an error preventing **Spaces** from being deleted in Kibana **9.1.0**"
+  - type: fix
+    components: [kbn]
+    text: "Corrected handling of `readonlyrest_kbn.whitelistedPaths` in `kibana.yml` when `xpack.security.enabled: true`"
+  - type: fix
+    components: [kbn]
+    text: "Resolved startup issues for Kibana versions **7.9.0 → 7.10.2**"
+  - type: fix
+    components: [kbn]
+    text: "Fixed report generation when `xpack.security.enabled: true` and `xpack.encryptedSavedObjects.encryptionKey` is set in Kibana **8.19.x** and **9.1.x**"

--- a/changelog/1.66.1.yaml
+++ b/changelog/1.66.1.yaml
@@ -1,0 +1,12 @@
+version: "1.66.1"
+release_date: "2025-09-03"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.1.5, 9.1.4, 9.0.8, 9.0.7 8.19.5, 8.19.4, 8.18.7 support"
+  - type: new
+    components: [es]
+    text: "9.1.5, 9.1.4, 9.0.8, 9.0.7, 8.19.5, 8.19.4, 8.18.8, 8.18.7 support"
+  - type: fix
+    components: [es]
+    text: "[Patching issue in Elasticsearch 9.x, 8.19.x, and 8.18.x that caused startup failures on Java 17](https://forum.readonlyrest.com/t/ror-1-65-1-java-17/2841)"

--- a/changelog/1.67.0.yaml
+++ b/changelog/1.67.0.yaml
@@ -1,0 +1,48 @@
+version: "1.67.0"
+release_date: "2025-10-14"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)"
+  - type: security
+    components: [es]
+    text: "[CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057), [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)"
+  - type: new
+    components: [es]
+    text: "[Added support for defining a custom audit serializer directly in ROR settings (no code required)](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)"
+  - type: new
+    components: [es]
+    text: "[Introduced new predefined audit serializers: `ReportingAllEventsAuditLogSerializer`, `ReportingAllEventsWithQueryAuditLogSerializer`](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers)"
+  - type: new
+    components: [es]
+    text: "Added new rules: [`ror_kbn_authentication`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authentication) and [`ror_kbn_authorization`](https://docs.readonlyrest.com/elasticsearch#ror_kbn_authorization), as alternatives to the existing `ror_kbn_auth` rule"
+  - type: enhancement
+    components: [kbn]
+    text: "[Added OIDC `clock-skew-tolerance` configuration option in `kibana.yml`](https://docs.readonlyrest.com/kibana#clock-skew-tolerance)"
+  - type: enhancement
+    components: [kbn]
+    text: "[Added option to disable Kibana termination on watermark errors in `kibana.yml`](https://docs.readonlyrest.com/kibana#terminate-kibana-on-es-high-watermark)"
+  - type: fix
+    components: [kbn]
+    text: "Logout did not invalidate the app session when the `ror_kbn_auth` rule was used with local group definitions"
+  - type: fix
+    components: [kbn]
+    text: "[Restored keyword field value suggestions in Discover/Data View filters](https://forum.readonlyrest.com/t/kibana-data-view-filter-not-working-with-keyword/2843)"
+  - type: fix
+    components: [kbn]
+    text: "Integration-based options were visible in search results even when the app was marked as hidden"
+  - type: fix
+    components: [kbn]
+    text: "Index Management appeared in app search results even when the app was declared as hidden"
+  - type: fix
+    components: [kbn]
+    text: "Resolved an issue with CSRF token override when multiple browser tabs were open"
+  - type: fix
+    components: [kbn]
+    text: "Fixed OIDC compatibility for Kibana 7.10.2 and earlier"
+  - type: fix
+    components: [es]
+    text: "Restored backward compatibility for custom audit log serializer implementations extending the `DefaultAuditLogSerializer` class. Custom serializers compiled against ROR 1.65 or 1.66 that use `DefaultAuditLogSerializer` must be recompiled to work correctly"
+  - type: fix
+    components: [es]
+    text: "Fixed a defect that broke the \"Snapshot and Restore\" functionality in Kibana"

--- a/changelog/1.67.1.yaml
+++ b/changelog/1.67.1.yaml
@@ -1,0 +1,30 @@
+version: "1.67.1"
+release_date: "2025-11-03"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.0, 9.1.6, 8.19.6 support"
+  - type: new
+    components: [es]
+    text: "9.2.0, 9.1.6, 8.19.6 support"
+  - type: enhancement
+    components: [es]
+    text: "Allow using the `actions` rule with the `kibana` rule in the same block when `kibana.access: unrestricted`"
+  - type: fix
+    components: [kbn]
+    text: "Fixed JWT handling for wrong license edition"
+  - type: fix
+    components: [kbn]
+    text: "Suppressed “Forbidden” toast in Discover/Dashboard on Kibana 8.x–9.x"
+  - type: fix
+    components: [kbn]
+    text: "[Resolved report download failure on Kibana 9.1.x](https://forum.readonlyrest.com/t/unable-to-download-reports-from-kibana/2859/2)"
+  - type: fix
+    components: [kbn]
+    text: "Fixed timeout when saving Security settings"
+  - type: fix
+    components: [kbn]
+    text: "Restored visibility of reports when multiple data streams exist for a reporting index"
+  - type: fix
+    components: [kbn]
+    text: "Fixed invisible reports for non-tenancy users on Kibana 9.1.x"

--- a/changelog/1.67.2.yaml
+++ b/changelog/1.67.2.yaml
@@ -1,0 +1,15 @@
+version: "1.67.2"
+release_date: "2025-11-13"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.1, 9.1.7, 8.19.7 support"
+  - type: new
+    components: [es]
+    text: "9.2.1, 9.1.7, 8.19.7 support"
+  - type: fix
+    components: [kbn]
+    text: "Fixed SAML/OIDC provider support behind a reverse proxy when `server.rewriteBasePath: false` is set in kibana.yml"
+  - type: fix
+    components: [es]
+    text: "Delegated handling of certain internal exceptions to Elasticsearch, preserving native error responses"

--- a/changelog/1.67.3.yaml
+++ b/changelog/1.67.3.yaml
@@ -1,0 +1,12 @@
+version: "1.67.3"
+release_date: "2025-11-29"
+entries:
+  - type: new
+    components: [kbn]
+    text: "9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support"
+  - type: new
+    components: [es]
+    text: "9.2.3, 9.2.2, 9.1.9, 9.1.8, 8.19.9, 8.19.8 support"
+  - type: fix
+    components: [es]
+    text: "Resolved index resolution compatibility issue with Elasticsearch 9.1.7"

--- a/changelog/1.68.0.yaml
+++ b/changelog/1.68.0.yaml
@@ -1,0 +1,60 @@
+version: "1.68.0"
+release_date: "2026-01-07"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2024-51999](https://nvd.nist.gov/vuln/detail/CVE-2024-51999), [CVE-2025-65945](https://nvd.nist.gov/vuln/detail/CVE-2025-65945)"
+  - type: security
+    components: [es]
+    text: "[CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735), [CVE-2025-66453](https://nvd.nist.gov/vuln/detail/CVE-2025-66453)"
+  - type: warning
+    components: [es]
+    text: "Audit outputs now use the round-robin strategy for custom audit clusters. [Audit nodes must belong to the same Elasticsearch cluster; otherwise, audit events may be incomplete](https://docs.readonlyrest.com/elasticsearch/audit#custom-audit-cluster)  for configuration guidelines."
+  - type: new
+    components: [kbn]
+    text: "9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support"
+  - type: new
+    components: [es]
+    text: "9.3.2, 9.3.1, 9.3.0, 9.2.7, 9.2.6, 9.2.5, 9.2.4, 9.1.10, 8.19.13, 8.19.12, 8.19.11, 8.19.10 support"
+  - type: new
+    components: [kbn]
+    text: "Added \"Remember last picked tenant\" feature for external identity providers"
+  - type: new
+    components: [kbn]
+    text: "Introduced support for the Kibana Data Set Quality beta application"
+  - type: new
+    components: [kbn]
+    text: "Restyled ROR menu featuring searchable tenancy selector"
+  - type: new
+    components: [es]
+    text: "Added new rules: [`jwt_authentication`](https://docs.readonlyrest.com/elasticsearch#jwt_authentication) and [`jwt_authorization`](https://docs.readonlyrest.com/elasticsearch#jwt_authorization), as alternatives to the existing `jwt_auth` rule"
+  - type: new
+    components: [es]
+    text: "[New audit log serializer compliant with Elastic Common Schema (ECS)](https://docs.readonlyrest.com/elasticsearch/audit#using-ecs-serializer)"
+  - type: new
+    components: [es]
+    text: "[The audit can be enabled or disabled on the block level](https://docs.readonlyrest.com/elasticsearch/audit#configuration)"
+  - type: enhancement
+    components: [kbn]
+    text: "Disabled caching in the Login CSRF protection mechanism."
+  - type: enhancement
+    components: [kbn]
+    text: "Made the tenant indicator always visible and improved its dropdown behavior"
+  - type: enhancement
+    components: [kbn]
+    text: "Added stack traces to ReadonlyREST KBN plugin error logs for easier debugging"
+  - type: enhancement
+    components: [es]
+    text: "[Added LDAP connection health checking to prevent stale connection authentication failures](https://forum.readonlyrest.com/t/ldap-connection-timeout-leads-to-authentication-error/2899)"
+  - type: enhancement
+    components: [es]
+    text: "[Enable nested field definitions in the configurable audit log serializer for more flexible audit logging](https://docs.readonlyrest.com/elasticsearch/audit#using-configurable-serializer)"
+  - type: enhancement
+    components: [es]
+    text: "[The predefined audit log serializers](https://docs.readonlyrest.com/elasticsearch/audit#predefined-serializers) now include a new `logged_user` field, which contains a human-readable username"
+  - type: fix
+    components: [kbn]
+    text: "Resolved an issue causing the Kibana Search Sessions app to fail on Kibana 8.x"
+  - type: fix
+    components: [es]
+    text: "[Fixed cluster resolution issues that caused Kibana errors and unexpected logouts in versions 8.19.x and above](https://forum.readonlyrest.com/t/errors-after-upgrade-kibana-7-17-29-to-8-19-7/2887)"

--- a/changelog/1.69.0.yaml
+++ b/changelog/1.69.0.yaml
@@ -1,0 +1,78 @@
+version: "1.69.0"
+release_date: "2026-04-02"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), [CVE-2025-69873](https://nvd.nist.gov/vuln/detail/CVE-2025-69873), [CVE-2026-2391](https://nvd.nist.gov/vuln/detail/CVE-2026-2391), [CVE-2026-25639](https://nvd.nist.gov/vuln/detail/CVE-2026-25639), [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904), [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449), [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599), [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750), [CVE-2026-4867](https://nvd.nist.gov/vuln/detail/CVE-2026-4867), [CVE-2026-34601](https://www.tenable.com/cve/CVE-2026-34601), [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/cve-2022-31129)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[Added Fleet support via native API key and service account token authentication (ES 7.14+)](https://docs.readonlyrest.com/elasticsearch/fleet)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard available in the Kibana plugin now supports audit events written to data streams"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard provided by the Kibana plugin can now be used with the ECS (Elastic Common Schema) audit index"
+  - type: new
+    components: [kbn]
+    text: "[Added support for opening different tenancies in separate tabs](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "[Added support for sharing links to Kibana visualizations for the selected tenancy](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "Added support for rolling upgrades when upgrading the ROR Elasticsearch plugin and ROR Kibana plugin in a cluster"
+  - type: enhancement
+    components: [kbn]
+    text: "Removed the need for manual username input in the impersonation mechanism"
+  - type: enhancement
+    components: [kbn]
+    text: "Fixed an error in Kibana caused by empty data streams in Kibana 8.18.0+"
+  - type: enhancement
+    components: [kbn]
+    text: "Added a fallback for an empty `indices` field in the Audit Dashboard"
+  - type: enhancement
+    components: [kbn]
+    text: "[Updated custom metadata examples to use the new method. `getIdentitySession` and `getAuthorizationHeaders` are now deprecated in favor of `getUserRequestIdentity`, `getIdentitySessionHeaders`, and `getWhitelistedHeaders`](https://docs.readonlyrest.com/develop/examples/custom-middleware)"
+  - type: enhancement
+    components: [es]
+    text: "[`token_authentication` rule extended with `api_key` and `service_token` types](https://docs.readonlyrest.com/elasticsearch#token_authentication)"
+  - type: enhancement
+    components: [es]
+    text: "[Audit log entries and ACL history now include a human-readable reason when a request is denied, making access-control troubleshooting significantly easier](https://forum.readonlyrest.com/t/distinguish-between-wrong-credentials-and-missing-permissions/2914)"
+  - type: enhancement
+    components: [es]
+    text: "Added the new `matched_block_names` field to audit entries created by audit log serializers other than ECS and custom serializers. The `reason` field is now deprecated."
+  - type: enhancement
+    components: [es]
+    text: "Users defined with LDAP, external, and `ror_kbn` authentication are no longer treated as local users by the impersonation mechanism"
+  - type: enhancement
+    components: [es]
+    text: "The ROR Kibana plugin can no longer be used when the `prompt_for_basic_auth: true` setting is configured"
+  - type: fix
+    components: [kbn]
+    text: "Resolved a memory leak related to direct calls via the Kibana API"
+  - type: fix
+    components: [kbn]
+    text: "No longer shows the \"Data Set Quality\" and \"Index management\" applications to users with RO or RO_strict access"
+  - type: fix
+    components: [kbn]
+    text: "Fixed JWT token authorization when using embedded Kibana"
+  - type: fix
+    components: [kbn]
+    text: "Fixed the styling of the page-not-found screen for Kibana 9.x"
+  - type: fix
+    components: [kbn]
+    text: "Correctly displays the \"Who uses what indices?\" Audit Dashboard visualization when indices are not specified in the audit events"
+  - type: fix
+    components: [es]
+    text: "[Improved stability when sending audit logs to another cluster, so temporary remote cluster outages no longer affect the main cluster](https://forum.readonlyrest.com/t/sending-logs-to-another-cluster/2925)"
+  - type: fix
+    components: [es]
+    text: "Fixed Search Profiler being inactive in Kibana 8.18.0+"
+  - type: fix
+    components: [es]
+    text: "`beshultd/elasticsearch-readonlyrest` images for ES 7.16.x, 7.17.0–7.17.6, and 8.0.x–8.4.x now ship with a patched JDK, replacing bundled JDK 17.0.0–17.0.4 / JDK 18, which crashes on cgroup v2 hosts due to JDK-8287073"

--- a/changelog/1.69.1.yaml
+++ b/changelog/1.69.1.yaml
@@ -1,0 +1,30 @@
+version: "1.69.1"
+release_date: "2026-04-10"
+entries:
+  - type: security
+    components: [kbn]
+    text: "Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)"
+  - type: new
+    components: [kbn]
+    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+  - type: new
+    components: [es]
+    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+  - type: new
+    components: [eck]
+    text: "3.4.0 support"
+  - type: fix
+    components: [kbn]
+    text: "Fixed `jsonwebtoken-ancient` being stripped from Kibana builds earlier than 7.11.0"
+  - type: fix
+    components: [kbn]
+    text: "Filtered out Fleet-based apps from search results when Management is hidden in Kibana 8.x and 9.x"
+  - type: fix
+    components: [kbn]
+    text: "Fixed `/pkp/session-probe` requests being blocked by browsers that enforce async-only calls"
+  - type: fix
+    components: [kbn]
+    text: "Fixed a problem with redirecting to the login form after a 401 error following a session probe check"
+  - type: fix
+    components: [es]
+    text: "Fixed a missing Kibana access policy in the metadata response when the matched ACL block has no `kibana` section configured"

--- a/detailed_changelog.md
+++ b/detailed_changelog.md
@@ -3,36 +3,39 @@
 ### (2026-04-10) What’s new in **ROR 1.69.1**
 <details>
 <summary><strong>🚨 Security Fix</strong> (KBN) Fixed vulnerability <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-2950">CVE-2026-2950</a></summary>
-Fixed a prototype pollution vulnerability (CVE-2026-2950) in the Lodash library used by Kibana. The issue allowed attackers to bypass a previous fix (CVE-2025-13465) by using array-wrapped path segments in `_.unset` and `_.omit` functions, potentially deleting properties from built-in prototypes. Patched by upgrading Lodash to version 4.18.0.
+Fixed a prototype pollution vulnerability (CVE-2026-2950) in the Lodash library used by the Kibana plugin. The issue allowed attackers to bypass a previous fix (CVE-2025-13465) by using array-wrapped path segments in the `_.unset` and `_.omit` functions, potentially enabling deletion of properties from built-in prototypes. The fix upgrades the affected dependency to a patched version.
 </details>
-
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**🚀 New** (KBN) 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
-
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**🚀 New** (ES) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
-
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**🚀 New** (ECK) 3.4.0 support
+<details>
+<summary><strong>🚀 New</strong> (KBN) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support</summary>
+Added compatibility with the latest Kibana versions: 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, and 8.19.14. Users running these Kibana releases can now install and use the ReadonlyREST plugin without compatibility issues.
+</details>
+<details>
+<summary><strong>🚀 New</strong> (ES) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support</summary>
+Added compatibility with the latest Elasticsearch versions: 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, and 8.19.14. Users running these Elasticsearch releases can now install and use the ReadonlyREST plugin without compatibility issues.
+</details>
+<details>
+<summary><strong>🚀 New</strong> (ECK) 3.4.0 support</summary>
+Added support for Elastic Cloud on Kubernetes (ECK) version 3.4.0, allowing users to deploy and manage ReadonlyREST within ECK-managed Elasticsearch clusters running on Kubernetes.
+</details>
 <details>
 <summary><strong>🐞 Fix</strong> (KBN) Fixed <code>jsonwebtoken-ancient</code> being stripped from Kibana builds earlier than 7.11.0</summary>
-Resolved an issue where the `jsonwebtoken-ancient` library was incorrectly removed from Kibana builds prior to version 7.11.0, which could cause authentication failures in older Kibana deployments.
+Fixed an issue where the `jsonwebtoken-ancient` dependency was incorrectly removed during the Kibana plugin build process for versions earlier than 7.11.0, which could cause authentication failures in environments relying on legacy JWT token handling.
 </details>
 <details>
 <summary><strong>🐞 Fix</strong> (KBN) Filtered out Fleet-based apps from search results when Management is hidden in Kibana 8.x and 9.x</summary>
-Fixed a Kibana UI issue where Fleet-based applications (e.g., Fleet, APM, Endpoint) would still appear in search results even when the Management section was hidden by ROR security rules. These apps are now properly filtered out.
+Fixed a cosmetic issue where Fleet-based applications (like Fleet, Integrations, etc.) would still appear in Kibana's global search results even when the Management section was hidden by security rules. These apps are now properly filtered out in Kibana 8.x and 9.x.
 </details>
 <details>
 <summary><strong>🐞 Fix</strong> (KBN) Fixed <code>/pkp/session-probe</code> requests being blocked by browsers that enforce async-only calls</summary>
-Addressed a browser compatibility issue where session probe requests to `/pkp/session-probe` were blocked by browsers enforcing async-only fetch calls. This fix ensures the session probe works correctly across all modern browsers.
+Fixed a compatibility issue where session probe requests to the `/pkp/session-probe` endpoint were being blocked by browsers enforcing async-only fetch calls. This ensures the session health check mechanism works correctly across all modern browsers.
 </details>
 <details>
 <summary><strong>🐞 Fix</strong> (KBN) Fixed a problem with redirecting to the login form after a 401 error following a session probe check</summary>
-Resolved a redirect loop issue where users were not properly redirected to the login form after receiving a 401 error during the session probe check, improving the authentication flow experience.
+Fixed a redirect loop issue where users were not properly redirected to the login form after receiving a 401 error during a session probe check. This ensures a smooth re-authentication flow when the session expires.
 </details>
 <details>
 <summary><strong>🐞 Fix</strong> (ES) Fixed a missing Kibana access policy in the metadata response when the matched ACL block has no <code>kibana</code> section configured</summary>
-Fixed an issue where the Elasticsearch metadata response was missing the Kibana access policy when the matched ACL rule block did not contain a `kibana` section. This ensures consistent metadata responses regardless of ACL configuration.
+Fixed an issue where the Elasticsearch plugin's metadata response was missing the Kibana access policy when the matched ACL block did not have a `kibana` section explicitly configured. This ensures consistent and correct metadata reporting for all ACL configurations.
 </details>
 
 ### (2026-04-02) What’s new in **ROR 1.69.0**


### PR DESCRIPTION
## Why

`develop` is the default branch but the changelog-form flow lives on `master` (`changelog_watch.yml` fires on master push). Two recent PRs landed directly on master:

- [#314](https://github.com/beshu-tech/readonlyrest-docs/pull/314) — 66-version YAML migration (already merged)
- [#315](https://github.com/beshu-tech/readonlyrest-docs/pull/315) — Phase 3 workflows + render + Issue Forms (open, **merge this first**)

Without this sync, develop drifts further from master, and the next `develop → master` release merge would conflict / re-introduce stale changelog state.

Pattern mirrors prior maintenance (e.g. `c215bd3 Merge branch 'master' into develop`).

## Stay draft until #315 merges

Before clicking "Ready for review":

1. Wait for #315 to merge into master
2. Rebase this branch on latest develop and re-merge master:
   ```bash
   git checkout sync/master-into-develop
   git fetch origin
   git reset --hard origin/develop
   git merge origin/master --no-edit
   git push --force-with-lease
   ```
3. Flip from draft → ready, merge as a regular merge commit (preserves the cross-branch history).

## Scope

Pure merge — no manual edits in this branch. Carries:
- `changelog/*.yaml` (66 versions migrated)
- `.github/workflows/changelog_form.yml`, `render_changelog.yml`, `maintainer_gate.yml`
- `.github/ISSUE_TEMPLATE/changelog-entry.yml` + `config.yml`
- `.github/schemas/changelog-entry.schema.json`
- `.github/changelog-config.yml`
- Modified `.github/workflows/changelog_watch.yml`

> <signature>🦀 **sent by Claude Code**</signature>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive release notes now available documenting versions 1.26.0 through 1.69.1, including security updates, new features, enhancements, and bug fixes across all releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beshu-tech/readonlyrest-docs/pull/316)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->