### PR TITLE
[RORDEV-2040] kibana 9.4.1 support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### (2026-04-10) What's new in **ROR 1.69.1**
 * **🚨Security Fix** (KBN) Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)
-* **🚀New** (KBN) 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
+* **🚀New** (KBN) 9.4.1, 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
 * **🚀New** (ES) 9.4.1, 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support
 * **🚀New** (ECK) 3.4.0 support
 * **🐞Fix** (KBN) Fixed `jsonwebtoken-ancient` being stripped from Kibana builds earlier than 7.11.0

--- a/changelog/1.69.1.yaml
+++ b/changelog/1.69.1.yaml
@@ -6,10 +6,10 @@ entries:
     text: "Fixed vulnerability [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950)"
   - type: new
     components: [kbn]
-    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+    text: "9.4.1, 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
   - type: new
     components: [es]
-    text: "9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
+    text: "9.4.1, 9.4.0, 9.3.4, 9.3.3, 9.2.8, 8.19.15, 8.19.14 support"
   - type: new
     components: [eck]
     text: "3.4.0 support"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ROR 1.69.1 release documentation to reflect support for version 9.4.1 for both Kibana and Elasticsearch components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beshu-tech/readonlyrest-docs/pull/317)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->